### PR TITLE
[New feature] mainmenu headroom opzionale

### DIFF
--- a/templates/italiapa/html/mod_menu/megamenu.php
+++ b/templates/italiapa/html/mod_menu/megamenu.php
@@ -27,6 +27,7 @@ if ($tagId = $params->get('tag_id', ''))
 
 ob_start();
 ?>
+<div class="Megamenu Megamenu--default js-megamenu u-background-50">
 <ul class="Megamenu-list Megamenu<?php echo $class_sfx; ?>"<?php echo $id; ?>>
 <?php 
 $buffer = ob_get_flush();
@@ -179,6 +180,7 @@ foreach ($list as $i => &$item)
 ob_start();
 ?>
 </ul>
+</div>
 <?php 
 $buffer = ob_get_flush();
 JLog::add(new JLogEntry($buffer, JLog::DEBUG, 'tpl_italiapa'));

--- a/templates/italiapa/html/modules.php
+++ b/templates/italiapa/html/modules.php
@@ -44,7 +44,7 @@ function modChrome_lg($module, &$params, &$attribs)
 	elseif ($module->position == 'mainmenu')
 	{
 		$moduleTag   = 'nav';
-		$moduleClass1 = 'Megamenu Megamenu--default js-megamenu '.$moduleClass;
+		$moduleClass1 = 'u-textCenter u-hidden u-sm-hidden u-md-block u-lg-block '.$moduleClass;
 	}
 	elseif ($module->position == 'lead')
 	{

--- a/templates/italiapa/index.php
+++ b/templates/italiapa/index.php
@@ -101,7 +101,7 @@ JLog::add(new JLogEntry('Template ItaliaPA', JLog::DEBUG, 'tpl_italiapa'));
 <header class="Header u-hiddenPrint<?php if ($this->params->get('headroom', 0)) echo ' Headroom--fixed js-Headroom Headroom Headroom--top Headroom--not-bottom" style="position: fixed; top: 0px;'; ?>">
 <?php if (($afferente = $this->params->get('afferente')) || ($this->countModules('languages'))) : ?>
 <div class="Header-banner">
-	<div class="Header-owner Headroom-hideme ">
+	<div class="Header-owner Headroom-hideme">
 	<?php if ($afferente = $this->params->get('afferente')) : ?>
 		<?php if ($afferente_link = $this->params->get('afferente_link')) : ?>
 		<a href="<?php echo $this->params->get('afferente_link'); ?>"><span><?php echo $afferente; ?></span></a>
@@ -181,9 +181,7 @@ JLog::add(new JLogEntry('Template ItaliaPA', JLog::DEBUG, 'tpl_italiapa'));
 <!-- Header-navbar -->
 
 <?php if ($this->countModules('mainmenu')) : ?>
-<div class="Headroom-hideme u-textCenter u-hidden u-sm-hidden u-md-block u-lg-block">
 	<jdoc:include type="modules" name="mainmenu" style="lg" />
-</div>
 <?php endif; ?>
 
 </header>


### PR DESCRIPTION
### Summary of Changes
Permetti di scegliere se il mainmenu deve essere visibile oppure no in caso di Headroom attivo
### Testing Instructions
Crea una pagina con megamenu in posizione mainmenu
![headroom_02](https://user-images.githubusercontent.com/12718836/32680690-214205da-c66c-11e7-86fc-68386786f2d6.png)
Abilita l'opzione Headroom
![headroom_01](https://user-images.githubusercontent.com/12718836/32680607-b9750dc6-c66b-11e7-86d3-e22736528909.png)
Scorri la pagina verso il basso
### Expected result
Il megamenu in posizione mainmenu deve rimanere visibile
![headroom_03](https://user-images.githubusercontent.com/12718836/32680715-41f2cde6-c66c-11e7-833b-6ab2bfbf344e.png)
### Actual result
I mega menu viene nascosto
![headroom_04](https://user-images.githubusercontent.com/12718836/32680743-6434f30c-c66c-11e7-9b4c-38e148dc0c48.png)
### Documentation Changes Required
Per nascondere il megamenu in posizione mainmenu aggiungere ' Headroom-hideme' come module class suffix
![headroom_05](https://user-images.githubusercontent.com/12718836/32680760-7e0de86a-c66c-11e7-946f-a5b2fd435532.png)

