### PR TITLE
stile titolo articoli category blog non conforme

### DIFF
--- a/templates/italiapa/html/com_content/category/blog_tile.php
+++ b/templates/italiapa/html/com_content/category/blog_tile.php
@@ -45,7 +45,7 @@ $assocParam = (JLanguageAssociations::isEnabled() && $params->get('show_associat
 			<?php echo $this->escape($this->item->title); ?>
 		</a>
 	<?php else : ?>
-		<?php echo $this->escape($this->item->title); ?>
+		<span class="u-text-h4 u-textClean u-color-black"><?php echo $this->escape($this->item->title); ?></span>
 	<?php endif; ?>
 	</h3>
 <?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue #4 .

### Summary of Changes
I titoli non ipertestuali hanno lo stesso stile dei titoli ipertestuali nel layout Articoli: Categoria blog


### Testing Instructions
Creare due voci di menu di tipo Articoli: Categoria blog.
In usa delle due disabilitare la voce Titoli ipertestuali tra le impostazioni Opzioni
![image](https://user-images.githubusercontent.com/12718836/32687161-c40b11ea-c6b6-11e7-9a5e-2a10e7109c90.png)
Nell'altra lasciarla abilitata

### Expected result
In entrambe le pagine il titolo ha lo stile definito dalle linee guida


### Actual result
Solo la pagina con l'opzione titolo ipertestuale attivo ha il titolo con lo stile definito dalle linee guida


### Documentation Changes Required

