### PR TITLE
rimosso meta charset

### DIFF
--- a/templates/italiapa/index.php
+++ b/templates/italiapa/index.php
@@ -37,7 +37,6 @@ JLog::add(new JLogEntry('Template ItaliaPA', JLog::DEBUG, 'tpl_italiapa'));
 <html class="no-js" lang="<?php echo $this->language; ?>">
 <!--<![endif]-->
 <head>
-	<meta charset="utf-8">
 	<meta http-equiv="x-ua-compatible" content="ie=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 


### PR DESCRIPTION
### Summary of Changes
Rimosso meta charset.

### Testing Instructions
Controllare una qualsiasi pagina che fa uso del template con Nu Html Checker

### Expected result
Nessun errore

### Actual result
A document must not include both a meta element with an http-equiv attribute whose value is content-type, and a meta element with a charset attribute.

### Documentation Changes Required

