### PR TITLE
Map responsive

### DIFF
--- a/templates/italiapa/css/custom.css
+++ b/templates/italiapa/css/custom.css
@@ -61,29 +61,12 @@ ul.tags li:nth-child(n+2):before {
   display: block;
 }
 
-.map-responsive16by9 {
-  overflow:hidden;
-  padding-bottom:56.25%;
-  position:relative;
-  height:0;
-}
-
-.map-responsive4by3 {
-  overflow:hidden;
-  padding-bottom:75%;
-  position:relative;
-  height:0;
-}
-
 .map-responsive {
   overflow:hidden;
-  padding-bottom:25%;
   position:relative;
   height:0;
 }
 
-.map-responsive16by9 iframe,
-.map-responsive4by3 iframe,
 .map-responsive iframe {
   left:0;
   top:0;
@@ -93,8 +76,78 @@ ul.tags li:nth-child(n+2):before {
   pointer-events: none;
 }
 
-.map-responsive16by9 iframe.clicked,
-.map-responsive4by3 iframe.clicked,
 .map-responsive iframe.clicked {
 	pointer-events: auto;
+}
+
+@media screen and (max-width: 767px) {
+	.map-xs-responsive4by3 {
+		padding-bottom:75%;
+	}
+
+	.map-xs-responsive16by9 {
+		padding-bottom:56.25%;
+	}
+
+	.map-xs-responsive3by1 {
+		padding-bottom:33.33%;
+	}
+
+	.map-xs-responsive {
+		padding-bottom:25%;
+	}
+}
+
+@media screen and (min-width: 768px) and (max-width: 991px) {
+	.map-sm-responsive4by3 {
+		padding-bottom:75%;
+	}
+
+	.map-sm-responsive16by9 {
+		padding-bottom:56.25%;
+	}
+
+	.map-sm-responsive3by1 {
+		padding-bottom:33.33%;
+	}
+
+	.map-sm-responsive {
+		padding-bottom:25%;
+	}
+}
+
+@media screen and (min-width: 992px) and (max-width: 1365px) {
+	.map-md-responsive4by3 {
+		padding-bottom:75%;
+	}
+
+	.map-md-responsive16by9 {
+		padding-bottom:56.25%;
+	}
+
+	.map-md-responsive3by1 {
+		padding-bottom:33.33%;
+	}
+
+	.map-md-responsive {
+		padding-bottom:25%;
+	}
+}
+
+@media screen and (min-width: 1366px) {
+	.map-lg-responsive4by3 {
+		padding-bottom:75%;
+	}
+
+	.map-lg-responsive16by9 {
+		padding-bottom:56.25%;
+	}
+
+	.map-lg-responsive3by1 {
+		padding-bottom:33.33%;
+	}
+
+	.map-lg-responsive {
+		padding-bottom:25%;
+	}
 }

--- a/templates/italiapa/css/custom.css
+++ b/templates/italiapa/css/custom.css
@@ -85,6 +85,7 @@ ul.tags li:nth-child(n+2):before {
 		padding-bottom:75%;
 	}
 
+	.map-responsive-default,
 	.map-xs-responsive16by9 {
 		padding-bottom:56.25%;
 	}
@@ -103,6 +104,7 @@ ul.tags li:nth-child(n+2):before {
 		padding-bottom:75%;
 	}
 
+	.map-responsive-default,
 	.map-sm-responsive16by9 {
 		padding-bottom:56.25%;
 	}
@@ -125,6 +127,7 @@ ul.tags li:nth-child(n+2):before {
 		padding-bottom:56.25%;
 	}
 
+	.map-responsive-default,
 	.map-md-responsive3by1 {
 		padding-bottom:33.33%;
 	}
@@ -143,6 +146,7 @@ ul.tags li:nth-child(n+2):before {
 		padding-bottom:56.25%;
 	}
 
+	.map-responsive-default,
 	.map-lg-responsive3by1 {
 		padding-bottom:33.33%;
 	}

--- a/templates/italiapa/css/custom.css
+++ b/templates/italiapa/css/custom.css
@@ -61,6 +61,13 @@ ul.tags li:nth-child(n+2):before {
   display: block;
 }
 
+.map-responsive16by9 {
+  overflow:hidden;
+  padding-bottom:56.25%;
+  position:relative;
+  height:0;
+}
+
 .map-responsive4by3 {
   overflow:hidden;
   padding-bottom:75%;
@@ -70,11 +77,12 @@ ul.tags li:nth-child(n+2):before {
 
 .map-responsive {
   overflow:hidden;
-  padding-bottom:56.25%;
+  padding-bottom:25%;
   position:relative;
   height:0;
 }
 
+.map-responsive16by9 iframe,
 .map-responsive4by3 iframe,
 .map-responsive iframe {
   left:0;

--- a/templates/italiapa/css/custom.css
+++ b/templates/italiapa/css/custom.css
@@ -90,4 +90,11 @@ ul.tags li:nth-child(n+2):before {
   height:100%;
   width:100%;
   position:absolute;
+  pointer-events: none;
+}
+
+.map-responsive16by9 iframe.clicked,
+.map-responsive4by3 iframe.clicked,
+.map-responsive iframe.clicked {
+	pointer-events: auto;
 }

--- a/templates/italiapa/index.php
+++ b/templates/italiapa/index.php
@@ -374,6 +374,7 @@ https://italia.github.io/design-web-toolkit/components/detail/footer.html
 <script src="<?php echo $this->baseurl ?>/templates/<?php echo $this->template ?>/js/uuid.min.js"></script>
 <script src="<?php echo $this->baseurl ?>/templates/<?php echo $this->template ?>/js/accordion.min.js"></script>
 <script src="<?php echo $this->baseurl ?>/templates/<?php echo $this->template ?>/js/table.min.js"></script>
+<script src="<?php echo $this->baseurl ?>/templates/<?php echo $this->template ?>/js/map.min.js"></script>
 <script src="<?php echo $this->baseurl ?>/templates/<?php echo $this->template ?>/build/IWT.min.js"></script>
 
 </body>

--- a/templates/italiapa/js/map.js
+++ b/templates/italiapa/js/map.js
@@ -1,4 +1,4 @@
-jQuery('.map-container')
+jQuery('.map-responsive')
 	.click(function(){
 		jQuery(this).find('iframe').addClass('clicked')})
 	.mouseleave(function(){

--- a/templates/italiapa/js/map.js
+++ b/templates/italiapa/js/map.js
@@ -1,0 +1,5 @@
+jQuery('.map-container')
+	.click(function(){
+		jQuery(this).find('iframe').addClass('clicked')})
+	.mouseleave(function(){
+		jQuery(this).find('iframe').removeClass('clicked')});

--- a/templates/italiapa/js/map.min.js
+++ b/templates/italiapa/js/map.min.js
@@ -1,0 +1,1 @@
+jQuery('.map-responsive').click(function(){jQuery(this).find('iframe').addClass('clicked')}).mouseleave(function(){jQuery(this).find('iframe').removeClass('clicked')});

--- a/templates/italiapa/templateDetails.xml
+++ b/templates/italiapa/templateDetails.xml
@@ -23,6 +23,7 @@
     <folder>html</folder>
     <filename>js/accordion.min.js</filename>
     <filename>js/drop.min.js</filename>
+    <filename>js/map.min.js</filename>
     <filename>js/table.min.js</filename>
     <filename>js/tether.min.js</filename>
     <filename>js/tooltip.min.js</filename>


### PR DESCRIPTION
### Summary of Changes
Aggiunte le classi per la gestione delle mappe Google responsive con scroll to zoom disabilitato.

### Testing Instructions
Creare un modulo personalizzato
Impostare Suffisso classe CSS modulo: map-responsive
Inserire il codice della mappa Google

### Expected result
Mappa Google responsive. Per attivare la funzione zoom cliccare sulla mappa.

### Actual result

### Documentation Changes Required
è possibile definire il formato mediante le classi
map-xs-responsive16by9
map-xs-responsive4by3
map-xs-responsive3by1
map-xs-responsive
map-sm-responsive16by9
map-sm-responsive4by3
map-sm-responsive3by1
map-sm-responsive
map-md-responsive16by9
map-md-responsive4by3
map-md-responsive3by1
map-md-responsive
map-lg-responsive16by9
map-lg-responsive4by3
map-lg-responsive3by1
map-lg-responsive
