### PR TITLE
fixes menu treeview layout

### DIFF
--- a/templates/italiapa/html/mod_menu/treeview-1.php
+++ b/templates/italiapa/html/mod_menu/treeview-1.php
@@ -17,5 +17,5 @@ defined('_JEXEC') or die;
 
 JLog::add(new JLogEntry(__FILE__, JLog::DEBUG, 'tpl_italiapa'));
 
-$maxlevel = 3;
+$maxlevel = 2;
 require JModuleHelper::getLayoutPath('mod_menu', 'treeview');

--- a/templates/italiapa/html/mod_menu/treeview-2.php
+++ b/templates/italiapa/html/mod_menu/treeview-2.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @package		Template ItaliaPA
+ * @subpackage	tpl_italiapa
+ *
+ * @author		Helios Ciancio <info@eshiol.it>
+ * @link		http://www.eshiol.it
+ * @copyright	Copyright (C) 2017, 2018 Helios Ciancio. All Rights Reserved
+ * @license		http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3
+ * Template ItaliaPA is free software. This version may have been modified
+ * pursuant to the GNU General Public License, and as distributed it includes
+ * or is derivative of works licensed under the GNU General Public License or
+ * other free or open source software licenses.
+ */
+
+defined('_JEXEC') or die;
+
+JLog::add(new JLogEntry(__FILE__, JLog::DEBUG, 'tpl_italiapa'));
+
+$maxlevel = 2;
+require JModuleHelper::getLayoutPath('mod_menu', 'treeview');

--- a/templates/italiapa/html/mod_menu/treeview-2.php
+++ b/templates/italiapa/html/mod_menu/treeview-2.php
@@ -17,5 +17,5 @@ defined('_JEXEC') or die;
 
 JLog::add(new JLogEntry(__FILE__, JLog::DEBUG, 'tpl_italiapa'));
 
-$maxlevel = 2;
+$maxlevel = 3;
 require JModuleHelper::getLayoutPath('mod_menu', 'treeview');

--- a/templates/italiapa/html/mod_menu/treeview-3.php
+++ b/templates/italiapa/html/mod_menu/treeview-3.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @package		Template ItaliaPA
+ * @subpackage	tpl_italiapa
+ *
+ * @author		Helios Ciancio <info@eshiol.it>
+ * @link		http://www.eshiol.it
+ * @copyright	Copyright (C) 2017, 2018 Helios Ciancio. All Rights Reserved
+ * @license		http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3
+ * Template ItaliaPA is free software. This version may have been modified
+ * pursuant to the GNU General Public License, and as distributed it includes
+ * or is derivative of works licensed under the GNU General Public License or
+ * other free or open source software licenses.
+ */
+
+defined('_JEXEC') or die;
+
+JLog::add(new JLogEntry(__FILE__, JLog::DEBUG, 'tpl_italiapa'));
+
+$maxlevel = 3;
+require JModuleHelper::getLayoutPath('mod_menu', 'treeview');

--- a/templates/italiapa/html/mod_menu/treeview.php
+++ b/templates/italiapa/html/mod_menu/treeview.php
@@ -78,7 +78,7 @@ $level = 1;
 		$class .= ' parent';
 	}
 
-	echo '<li role="treeitem" class="' . $class . '"'.((($level < 3) && $params->get('showAllChildren', false)) ? 'aria-expanded="true"' : '').'>';
+	echo '<li role="treeitem" class="' . $class . '">';
 
 	switch ($item->type) :
 		case 'separator':

--- a/templates/italiapa/html/mod_menu/treeview.php
+++ b/templates/italiapa/html/mod_menu/treeview.php
@@ -5,7 +5,7 @@
  *
  * @author		Helios Ciancio <info@eshiol.it>
  * @link		http://www.eshiol.it
- * @copyright	Copyright (C) 2017 Helios Ciancio. All Rights Reserved
+ * @copyright	Copyright (C) 2017, 2018 Helios Ciancio. All Rights Reserved
  * @license		http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3
  * Template ItaliaPA is free software. This version may have been modified
  * pursuant to the GNU General Public License, and as distributed it includes
@@ -22,18 +22,31 @@ $id = '';
 
 if ($tagId = $params->get('tag_id', ''))
 {
-	$id = ' id="' . $tagId . '"';
+    $id = ' id="' . $tagId . '"';
 }
+if (!isset($maxlevel)) $maxlevel = 1;
+/**
+ $tmp_class_sfx = explode(' ', $class_sfx);
+ for($i = 0; $i < count($tmp_class_sfx); $i++)
+ {
+ if (substr($tmp_class_sfx[$i], 0, 6) == 'level:')
+ {
+ $maxlevel = (int)substr($tmp_class_sfx[$i], 6);
+ unset($tmp_class_sfx[$i]);
+ }
+ }
+ $class_sfx = implode(' ', $tmp_class_sfx);
+ */
 if (empty($class_sfx))
 {
-	$class_sfx = 'Treeview--default';
+    $class_sfx = 'Treeview--default';
 }
 $level = 1;
 ?>
 <ul class="Linklist Linklist--padded Treeview js-Treeview u-text-r-xs <?php echo $class_sfx; ?>"<?php echo $id; ?>>
 <?php foreach ($list as $i => &$item)
 {
-	$class = 'item-' . $item->id;
+    $class = 'item-' . $item->id;
 
 	if ($item->id == $default_id)
 	{
@@ -78,7 +91,7 @@ $level = 1;
 		$class .= ' parent';
 	}
 
-	echo '<li role="treeitem" class="' . $class . '">';
+	echo '<li role="treeitem" class="' . $class . '"'.((($level < $maxlevel) && $params->get('showAllChildren', false)) ? 'aria-expanded="true"' : '').'>';
 
 	switch ($item->type) :
 		case 'separator':


### PR DESCRIPTION
Pull Request for Issue #39.

### Summary of Changes
I menu con layout Treeview vengono visualizzati con tutte le voci chiuse, con le voci del primo livello aperte (treeview-1) o con le voci del secondo livello aperte (treeview-2)

### Testing Instructions
Creare un modulu di menu ed assegnargli il layout Treeview (treeview-1 o treeview-2)
![treeview0001](https://user-images.githubusercontent.com/12718836/35214104-5400199e-ff60-11e7-9c38-d94a58c8a818.png)


### Expected result
Menu visualizzato con tutte le voci chiuse (voci di primo livello aperte, voci di secondo livello aperte)

### Actual result
Menu visualizzato con le voci fini al terzo livello aperte

### Documentation Changes Required
