### PR TITLE
articolo paginato

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_content_ipapagebreak.ini
+++ b/administrator/language/en-GB/en-GB.plg_content_ipapagebreak.ini
@@ -1,0 +1,21 @@
+; Page Break - plg_content_ipapagebreak
+; Copyright (C) 2018 Helios Ciancio. All rights reserved.
+; License GNU General Public License version 3 or later; see LICENSE
+; Note : All ini files need to be saved as UTF-8
+
+PLG_CONTENT_IPAPAGEBREAK="Content - Page Break for ItaliaPA Template"
+PLG_CONTENT_IPAPAGEBREAK_ALL_PAGES=" All Pages"
+PLG_CONTENT_IPAPAGEBREAK_ARTICLE_INDEX="Article Index"
+PLG_CONTENT_IPAPAGEBREAK_NO_TITLE="No title"
+PLG_CONTENT_IPAPAGEBREAK_PAGE_NUM="Page %s"
+PLG_CONTENT_IPAPAGEBREAK_SHOW_ALL_DESC="Displays the full article."
+PLG_CONTENT_IPAPAGEBREAK_SHOW_ALL_LABEL="Show All"
+PLG_CONTENT_IPAPAGEBREAK_SITE_ARTICLEINDEXTEXT="Custom Article Index Heading"
+PLG_CONTENT_IPAPAGEBREAK_SITE_ARTICLEINDEXTEXT_DESC="Enter a custom text for the Article Index Heading. If empty, standard will be used."
+PLG_CONTENT_IPAPAGEBREAK_SITE_ARTICLEINDEX_DESC="Show or hide Article Index Heading. The Heading displays on top of the Table of Contents."
+PLG_CONTENT_IPAPAGEBREAK_SITE_ARTICLEINDEX_LABEL="Article Index Heading"
+PLG_CONTENT_IPAPAGEBREAK_SITE_TITLE_DESC="Title and heading attributes from Plugin added to Site Title tag."
+PLG_CONTENT_IPAPAGEBREAK_SITE_TITLE_LABEL="Show Site Title"
+PLG_CONTENT_IPAPAGEBREAK_TOC_DESC="Display a table of contents on multipage Articles."
+PLG_CONTENT_IPAPAGEBREAK_TOC_LABEL="Table of Contents"
+PLG_CONTENT_IPAPAGEBREAK_XML_DESCRIPTION="Allow the creation of a paginated article with an optional table of contents.<br /><br />Insert page breaks through the use of the page break button normally found beneath the text panel in an Article. The location of the page break in an article will be displayed in the editor as a simple horizontal line.<br /><br />The text displayed will depend on the options chosen and may be either the title, alternate text (if provided) or page numbers. <br /><br />The HTML usage is:<br />&lt;hr class=&quot;system-pagebreak&quot; /&gt;<br />&lt;hr class=&quot;system-pagebreak&quot; title=&quot;The page title&quot; /&gt; or <br />&lt;hr class=&quot;system-pagebreak&quot; alt=&quot;The first page&quot; /&gt; or <br />&lt;hr class=&quot;system-pagebreak&quot; title=&quot;The page title&quot; alt=&quot;The first page&quot; /&gt; or <br />&lt;hr class=&quot;system-pagebreak&quot; alt=&quot;The first page&quot; title=&quot;The page title&quot; /&gt;"

--- a/administrator/language/en-GB/en-GB.plg_content_ipapagebreak.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_content_ipapagebreak.sys.ini
@@ -1,0 +1,7 @@
+; Page Break - plg_content_ipapagebreak
+; Copyright (C) 2018 Helios Ciancio. All rights reserved.
+; License GNU General Public License version 3 or later; see LICENSE
+; Note : All ini files need to be saved as UTF-8
+
+PLG_CONTENT_IPAPAGEBREAK="Content - Page Break for ItaliaPA Template"
+PLG_CONTENT_IPAPAGEBREAK_XML_DESCRIPTION="Allow the creation of a paginated article with an optional table of contents.<br /><br />Insert page breaks through the use of the page break button normally found beneath the text panel in an Article. The location of the page break in an article will be displayed in the editor as a simple horizontal line.<br /><br />The text displayed will depend on the options chosen and may be either the title, alternate text (if provided) or page numbers. <br /><br />The HTML usage is:<br />&lt;hr class=&quot;system-pagebreak&quot; /&gt;<br />&lt;hr class=&quot;system-pagebreak&quot; title=&quot;The page title&quot; /&gt; or <br />&lt;hr class=&quot;system-pagebreak&quot; alt=&quot;The first page&quot; /&gt; or <br />&lt;hr class=&quot;system-pagebreak&quot; title=&quot;The page title&quot; alt=&quot;The first page&quot; /&gt; or <br />&lt;hr class=&quot;system-pagebreak&quot; alt=&quot;The first page&quot; title=&quot;The page title&quot; /&gt;"

--- a/administrator/language/it-IT/it-IT.plg_content_ipapagebreak.ini
+++ b/administrator/language/it-IT/it-IT.plg_content_ipapagebreak.ini
@@ -1,0 +1,21 @@
+; Page Break - plg_content_ipapagebreak
+; Copyright (C) 2018 Helios Ciancio. All rights reserved.
+; License GNU General Public License version 3 or later; see LICENSE
+; Note : All ini files need to be saved as UTF-8
+
+PLG_CONTENT_IPAPAGEBREAK="Content - Pagebreak for ItaliaPA Template"
+PLG_CONTENT_IPAPAGEBREAK_ALL_PAGES=" Tutte le pagine"
+PLG_CONTENT_IPAPAGEBREAK_ARTICLE_INDEX="Indice articoli"
+PLG_CONTENT_IPAPAGEBREAK_NO_TITLE="Nessun titolo"
+PLG_CONTENT_IPAPAGEBREAK_PAGE_NUM="Pagina %s"
+PLG_CONTENT_IPAPAGEBREAK_SHOW_ALL_DESC="Visualizza tutto l'articolo"
+PLG_CONTENT_IPAPAGEBREAK_SHOW_ALL_LABEL="Mostra tutto"
+PLG_CONTENT_IPAPAGEBREAK_SITE_ARTICLEINDEXTEXT="Personalizza intestazione indice articolo"
+PLG_CONTENT_IPAPAGEBREAK_SITE_ARTICLEINDEXTEXT_DESC="Inserisci un testo personalizzato per l'intestazione dell'indice dell'articolo. Se vuoto, verrà utilizzato quello standard."
+PLG_CONTENT_IPAPAGEBREAK_SITE_ARTICLEINDEX_DESC="Mostra o nasconde l'intestazione dell'indice dell'articolo. L'intestazione si visualizza sopra alla tabella dei contenuti."
+PLG_CONTENT_IPAPAGEBREAK_SITE_ARTICLEINDEX_LABEL="Intestazione indice articolo"
+PLG_CONTENT_IPAPAGEBREAK_SITE_TITLE_DESC="Attributi titolo ed intestazione aggiunti dal plugin al titolo del sito"
+PLG_CONTENT_IPAPAGEBREAK_SITE_TITLE_LABEL="Titolo sito"
+PLG_CONTENT_IPAPAGEBREAK_TOC_DESC="Mostra una tabella dei contenuti per articoli con più pagine."
+PLG_CONTENT_IPAPAGEBREAK_TOC_LABEL="Tabella dei contenuti"
+PLG_CONTENT_IPAPAGEBREAK_XML_DESCRIPTION="Consente la creazione di un articolo impaginato con una tabella dei contenuti. Inserisci l'interruzione di pagina con l'utilizzo del pulsante Pagebreak che si trova nella parte inferiore del testo di un articolo. Il Pagebreak verrà visualizzato nella finestra del testo come una singola linea orizzontale. <br /> Il testo visualizzato dipenderà dalle opzioni scelte, cioè il titolo, il testo aletrnativo (se fornito) o i numeri di pagina. <br/> <br/>Il codice HTML utilizzato è:<br/>&lt;hr class="_QQ_"system-pagebreak"_QQ_" title="_QQ_"Titolo pagina"_QQ_" /&gt; o <br />&lt;hr class="_QQ_"system-pagebreak"_QQ_" alt="_QQ_"Prima pagina"_QQ_" /&gt; o <br />&lt;hr class="_QQ_"system-pagebreak"_QQ_" title="_QQ_"Titolo pagina"_QQ_" alt="_QQ_"Prima pagina"_QQ_" /&gt; o <br />&lt;hr class="_QQ_"system-pagebreak"_QQ_" alt="_QQ_"Prima pagina"_QQ_" title="_QQ_"Titolo pagina"_QQ_" /&gt;"

--- a/administrator/language/it-IT/it-IT.plg_content_ipapagebreak.sys.ini
+++ b/administrator/language/it-IT/it-IT.plg_content_ipapagebreak.sys.ini
@@ -1,0 +1,7 @@
+; Page Break - plg_content_ipapagebreak
+; Copyright (C) 2018 Helios Ciancio. All rights reserved.
+; License GNU General Public License version 3 or later; see LICENSE
+; Note : All ini files need to be saved as UTF-8
+
+PLG_CONTENT_IPAPAGEBREAK="Content - Pagebreak for ItaliaPA Template"
+PLG_CONTENT_IPAPAGEBREAK_XML_DESCRIPTION="Consente la creazione di un articolo impaginato con una tabella dei contenuti. Inserisci l'interruzione di pagina con l'utilizzo del pulsante Pagebreak che si trova nella parte inferiore del testo di un articolo. Il Pagebreak verrà visualizzato nella finestra del testo come una singola linea orizzontale. <br /> Il testo visualizzato dipenderà dalle opzioni scelte, cioè il titolo, il testo aletrnativo (se fornito) o i numeri di pagina. <br/> <br/>Il codice HTML utilizzato è:<br/>&lt;hr class="_QQ_"system-pagebreak"_QQ_" title="_QQ_"Titolo pagina"_QQ_" /&gt; o <br />&lt;hr class="_QQ_"system-pagebreak"_QQ_" alt="_QQ_"Prima pagina"_QQ_" /&gt; o <br />&lt;hr class="_QQ_"system-pagebreak"_QQ_" title="_QQ_"Titolo pagina"_QQ_" alt="_QQ_"Prima pagina"_QQ_" /&gt; o <br />&lt;hr class="_QQ_"system-pagebreak"_QQ_" alt="_QQ_"Prima pagina"_QQ_" title="_QQ_"Titolo pagina"_QQ_" /&gt;"

--- a/plugins/content/ipapagebreak/ipapagebreak.php
+++ b/plugins/content/ipapagebreak/ipapagebreak.php
@@ -1,0 +1,348 @@
+<?php
+/**
+ * @package		Template ItaliaPA
+ * @subpackage	plg_content_ipapagebreak
+ *
+ * @author		Helios Ciancio <info@eshiol.it>
+ * @link		http://www.eshiol.it
+ * @copyright	Copyright (C) 2018 Helios Ciancio. All Rights Reserved
+ * @license		http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3
+ * Template ItaliaPA is free software. This version may have been modified
+ * pursuant to the GNU General Public License, and as distributed it includes
+ * or or is derivative of works licensed under the GNU General Public License or or
+ * other free or open source software licenses.
+ */
+
+// no direct access
+defined('_JEXEC') or die('Restricted access.');
+
+use Joomla\String\StringHelper;
+
+jimport('joomla.utilities.utility');
+
+/**
+ * Page break plugin
+ *
+ * <b>Usage:</b>
+ * <code><hr class="system-pagebreak" /></code>
+ * <code><hr class="system-pagebreak" title="The page title" /></code>
+ * or
+ * <code><hr class="system-pagebreak" alt="The first page" /></code>
+ * or
+ * <code><hr class="system-pagebreak" title="The page title" alt="The first page" /></code>
+ * or
+ * <code><hr class="system-pagebreak" alt="The first page" title="The page title" /></code>
+ *
+ * @since  1.6
+ */
+class PlgContentIpapagebreak extends JPlugin
+{
+	/**
+	 * Plugin that adds a pagebreak into the text and truncates text at that point
+	 *
+	 * @param   string   $context  The context of the content being passed to the plugin.
+	 * @param   object   &$row     The article object.  Note $article->text is also available
+	 * @param   mixed    &$params  The article params
+	 * @param   integer  $page     The 'page' number
+	 *
+	 * @return  mixed  Always returns void or true
+	 *
+	 * @since   1.6
+	 */
+	public function onContentPrepare($context, &$row, &$params, $page = 0)
+	{
+		$canProceed = $context === 'com_content.article';
+
+		if (!$canProceed)
+		{
+			return;
+		}
+
+		// Expression to search for.
+		$regex = '#<hr(.*)class="system-pagebreak"(.*)\/>#iU';
+
+		$input = JFactory::getApplication()->input;
+
+		$print = $input->getBool('print');
+		$showall = $input->getBool('showall');
+
+		if (!$this->params->get('enabled', 1))
+		{
+			$print = true;
+		}
+
+		if ($print)
+		{
+			$row->text = preg_replace($regex, '<br />', $row->text);
+
+			return true;
+		}
+
+		// Simple performance check to determine whether bot should process further.
+		if (StringHelper::strpos($row->text, 'class="system-pagebreak') === false)
+		{
+			if ($page > 0)
+			{
+				throw new Exception(JText::_('JERROR_PAGE_NOT_FOUND'), 404);
+			}
+			
+			return true;
+		}
+
+		$view = $input->getString('view');
+		$full = $input->getBool('fullview');
+
+		if (!$page)
+		{
+			$page = 0;
+		}
+
+		if ($full || $view !== 'article' || $params->get('intro_only') || $params->get('popup'))
+		{
+			$row->text = preg_replace($regex, '', $row->text);
+
+			return;
+		}
+
+		// Load plugin language files only when needed (ex: not needed if no system-pagebreak class exists).
+		$this->loadLanguage();
+
+		// Find all instances of plugin and put in $matches.
+		$matches = array();
+		preg_match_all($regex, $row->text, $matches, PREG_SET_ORDER);
+
+		if ($showall && $this->params->get('showall', 1))
+		{
+			$hasToc = $this->params->get('multipage_toc', 1);
+
+			if ($hasToc)
+			{
+				// Display TOC.
+				$page = 1;
+				$this->_createToc($row, $matches, $page);
+			}
+			else
+			{
+				$row->toc = '';
+			}
+
+			$row->text = preg_replace($regex, '<br />', $row->text);
+
+			return true;
+		}
+
+		// Split the text around the plugin.
+		$text = preg_split($regex, $row->text);
+
+		if (!isset($text[$page]))
+		{
+			throw new Exception(JText::_('JERROR_PAGE_NOT_FOUND'), 404);
+		}
+
+		// Count the number of pages.
+		$n = count($text);
+
+		// We have found at least one plugin, therefore at least 2 pages.
+		if ($n > 1)
+		{
+			$title  = $this->params->get('title', 1);
+			$hasToc = $this->params->get('multipage_toc', 1);
+/**
+			// Adds heading or title to <site> Title.
+			if ($title && $page && isset($matches[$page - 1], $matches[$page - 1][2]))
+			{
+				$attrs = JUtility::parseAttributes($matches[$page - 1][1]);
+
+				if (isset($attrs['title']))
+				{
+					$row->page_title = $attrs['title'];
+				}
+			}
+*/
+			// Reset the text, we already hold it in the $text array.
+			$row->text = '';
+
+			// Display TOC.
+			if ($hasToc)
+			{
+				$this->_createToc($row, $matches, $page);
+			}
+			else
+			{
+				$row->toc = '';
+			}
+
+			// Page text.
+			$text[$page] = str_replace('<hr id="system-readmore" />', '', $text[$page]);
+			$row->text .= $text[$page];
+			
+			// $row->text .= '<br />';
+			$row->text .= '<div class="pager">';
+			
+			// Adds navigation between pages to bottom of text.
+			if ($hasToc)
+			{
+				$this->_createNavigation($row, $page, $n);
+			}
+
+			// Page links shown at bottom of page if TOC disabled.
+			if (!$hasToc)
+			{
+				$row->text .= $pageNav->getPagesLinks();
+			}
+
+			$row->text .= '</div>';
+		}
+
+		return true;
+	}
+
+	/**
+	 * Creates a Table of Contents for the pagebreak
+	 *
+	 * @param   object   &$row      The article object.  Note $article->text is also available
+	 * @param   array    &$matches  Array of matches of a regex in onContentPrepare
+	 * @param   integer  &$page     The 'page' number
+	 *
+	 * @return  void
+	 *
+	 * @since  1.6
+	 */
+	protected function _createToc(&$row, &$matches, &$page)
+	{
+		$heading = isset($row->title) ? $row->title : JText::_('PLG_CONTENT_IPAPAGEBREAK_NO_TITLE');
+		$input = JFactory::getApplication()->input;
+		$limitstart = $input->getUInt('limitstart', 0);
+		$showall = $input->getInt('showall', 0);
+
+		// TOC header.
+		$row->toc = '<div class="u-sizeFull u-text-r-s u-color-70">';
+
+		if ($this->params->get('article_index') == 1)
+		{
+			$headingtext = JText::_('PLG_CONTENT_IPAPAGEBREAK_ARTICLE_INDEX');
+
+			if ($this->params->get('article_index_text'))
+			{
+				$headingtext = htmlspecialchars($this->params->get('article_index_text'), ENT_QUOTES, 'UTF-8');
+			}
+
+			$row->toc .= '<h3 class="u-border-bottom-m"><span class="u-block u-text-h3 u-textClean u-color-60">' . $headingtext . '</span></h3>';
+		}
+
+		// TOC first Page link.
+		$row->toc .= '<ul class="Linklist Prose u-text-r-xs">
+		<li>
+			<a href="'
+			. JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language) . '&showall=&limitstart=')
+			. '">' . $heading . '</a>
+		</li>
+		';
+
+		$i = 2;
+
+		foreach ($matches as $bot)
+		{
+			$link = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language) . '&showall=&limitstart=' . ($i - 1));
+
+			if (@$bot[0])
+			{
+				$attrs2 = JUtility::parseAttributes($bot[0]);
+
+				if (@$attrs2['alt'])
+				{
+					$title = stripslashes($attrs2['alt']);
+				}
+				elseif (@$attrs2['title'])
+				{
+					$title = stripslashes($attrs2['title']);
+				}
+				else
+				{
+					$title = JText::sprintf('PLG_CONTENT_IPAPAGEBREAK_PAGE_NUM', $i);
+				}
+			}
+			else
+			{
+				$title = JText::sprintf('PLG_CONTENT_IPAPAGEBREAK_PAGE_NUM', $i);
+			}
+
+			$row->toc .= '<li><a href="' . $link . '">' . $title . '</a></li>';
+			$i++;
+		}
+
+		if ($this->params->get('showall'))
+		{
+			$link      = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language) . '&showall=1&limitstart=');
+			$row->toc .= '<li><a href="' . $link . '">'
+				. JText::_('PLG_CONTENT_IPAPAGEBREAK_ALL_PAGES') . ' <span class="Icon Icon-chevron-right"></span></a></li>';
+		}
+
+		$row->toc .= '</ul></div>';
+	}
+
+	/**
+	 * Creates the navigation for the item
+	 *
+	 * @param   object  &$row  The article object.  Note $article->text is also available
+	 * @param   int     $page  The total number of pages
+	 * @param   int     $n     The page number
+	 *
+	 * @return  void
+	 *
+	 * @since   1.6
+	 */
+	protected function _createNavigation(&$row, $page, $n)
+	{
+		$pnSpace = '';
+
+		if (JText::_('JGLOBAL_LT') || JText::_('JGLOBAL_LT'))
+		{
+			$pnSpace = ' ';
+		}
+
+		if ($page < $n - 1)
+		{
+			$page_next = $page + 1;
+
+			$link_next = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language) . '&showall=&limitstart=' . $page_next);
+
+			// Next >>
+			$next = '<a href="' . $link_next . '" class="u-color-50 u-textClean u-block"><span class="Icon-chevron-right u-text-r-s" role="presentation"></span><span class="u-hiddenVisually">' . JText::_('JNEXT') . '</span></a>';
+		}
+		else
+		{
+		    $next = '<span class="u-color-50 u-textClean u-block"><span class="Icon-chevron-right u-text-r-s" role="presentation"></span><span class="u-hiddenVisually">' . JText::_('JNEXT') . '</span></span>';
+		}
+
+		if ($page > 0)
+		{
+			$page_prev = $page - 1 === 0 ? '' : $page - 1;
+
+			$link_prev = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language) . '&showall=&limitstart=' . $page_prev);
+
+			// << Prev
+			$prev = '<a href="' . $link_prev . '" class="u-color-50 u-textClean u-block"><span class="Icon-chevron-left u-text-r-s" role="presentation"></span><span class="u-hiddenVisually">' . JText::_('JPREV') . '</span></a>';
+		}
+		else
+		{
+		    $prev = '<span class="u-color-50 u-textClean u-block"><span class="Icon-chevron-left u-text-r-s" role="presentation"></span><span class="u-hiddenVisually">' . JText::_('JPREV') . '</span></span>';
+		}
+
+		$row->text .= '<nav role="navigation" aria-label="Navigazione paginata" class="u-padding-top-xxl"><ul class="Grid Grid--fit Grid--alignMiddle u-text-r-xxs">';
+		
+		$row->text .= '<li class="Grid-cell u-textCenter">' . $prev . ' </li>';
+		
+		// Traditional mos page navigation
+		$pageNav = new JPagination($n, $page, 1);
+		
+		// Page counter.
+		$row->text .= '<li class="Grid-cell u-textCenter"><div class="pagenavcounter">';
+		$row->text .= $pageNav->getPagesCounter();
+		$row->text .= '</div></li>';
+		
+		$row->text .= '<li class="Grid-cell u-textCenter">' . $next . '</li>';
+		
+		$row->text .= '</ul></nav>';
+	}
+}

--- a/plugins/content/ipapagebreak/ipapagebreak.php
+++ b/plugins/content/ipapagebreak/ipapagebreak.php
@@ -51,7 +51,7 @@ class PlgContentIpapagebreak extends JPlugin
 	 */
 	public function onContentPrepare($context, &$row, &$params, $page = 0)
 	{
-		$canProceed = $context === 'com_content.article';
+	    $canProceed = ($context === 'com_content.article') && (!JPluginHelper::getPlugin('content', 'pagebreak'));
 
 		if (!$canProceed)
 		{
@@ -81,11 +81,12 @@ class PlgContentIpapagebreak extends JPlugin
 		// Simple performance check to determine whether bot should process further.
 		if (StringHelper::strpos($row->text, 'class="system-pagebreak') === false)
 		{
-			if ($page > 0)
+/**
+		    if ($page > 0)
 			{
 				throw new Exception(JText::_('JERROR_PAGE_NOT_FOUND'), 404);
 			}
-			
+*/			
 			return true;
 		}
 

--- a/plugins/content/ipapagebreak/ipapagebreak.xml
+++ b/plugins/content/ipapagebreak/ipapagebreak.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension version="3.1" type="plugin" group="content" method="upgrade">
+  <name>plg_content_ipapagebreak</name>
+  <author>Helios Ciancio</author>
+  <creationDate>January 2018</creationDate>
+  <copyright>(C) 2018 Helios Ciancio. All rights reserved.</copyright>
+  <license>http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3</license>
+  <authorEmail>info@eshiol.it</authorEmail>
+  <authorUrl>www.eshiol.it</authorUrl>
+  <version>3.8.0.1</version>
+  <description>PLG_CONTENT_IPAPAGEBREAK_XML_DESCRIPTION</description>
+  <updateservers>
+    <server type="extension" priority="2" name="Italia Template - Content - Page Break for Italia PA Plugin">https://www.eshiol.it/files/italiapa/plg_content_ipapagebreak.xml</server>
+  </updateservers>
+	
+  <files>
+    <filename plugin="ipapagebreak">ipapagebreak.php</filename>
+  </files>
+  <languages folder="language">
+    <language tag="en-GB">en-GB/en-GB.plg_content_ipapagebreak.ini</language>
+    <language tag="en-GB">en-GB/en-GB.plg_content_ipapagebreak.sys.ini</language>
+    <language tag="it-IT">it-IT/it-IT.plg_content_ipapagebreak.ini</language>
+    <language tag="it-IT">it-IT/it-IT.plg_content_ipapagebreak.sys.ini</language>
+  </languages>
+
+	<config>
+		<fields name="params">
+			<fieldset name="basic">
+				<field
+					name="title"
+					type="radio"
+					label="PLG_CONTENT_IPAPAGEBREAK_SITE_TITLE_LABEL"
+					description="PLG_CONTENT_IPAPAGEBREAK_SITE_TITLE_DESC"
+					class="btn-group btn-group-yesno"
+					default="1"
+					>
+					<option value="1">JSHOW</option>
+					<option value="0">JHIDE</option>
+				</field>
+
+				<field
+					name="article_index"
+					type="radio"
+					label="PLG_CONTENT_IPAPAGEBREAK_SITE_ARTICLEINDEX_LABEL"
+					description="PLG_CONTENT_IPAPAGEBREAK_SITE_ARTICLEINDEX_DESC"
+					class="btn-group btn-group-yesno"
+					default="1"
+					>
+					<option value="1">JSHOW</option>
+					<option value="0">JHIDE</option>
+				</field>
+
+				<field
+					name="article_index_text"
+					type="text"
+					label="PLG_CONTENT_IPAPAGEBREAK_SITE_ARTICLEINDEXTEXT"
+					description="PLG_CONTENT_IPAPAGEBREAK_SITE_ARTICLEINDEXTEXT_DESC"
+					default=""
+					showon="article_index:1"
+				/>
+
+				<field
+					name="multipage_toc"
+					type="radio"
+					label="PLG_CONTENT_IPAPAGEBREAK_TOC_LABEL"
+					description="PLG_CONTENT_IPAPAGEBREAK_TOC_DESC"
+					class="btn-group btn-group-yesno"
+					default="1"
+					>
+					<option value="1">JSHOW</option>
+					<option value="0">JHIDE</option>
+				</field>
+
+				<field
+					name="showall"
+					type="radio"
+					label="PLG_CONTENT_IPAPAGEBREAK_SHOW_ALL_LABEL"
+					description="PLG_CONTENT_IPAPAGEBREAK_SHOW_ALL_DESC"
+					class="btn-group btn-group-yesno"
+					default="1"
+					>
+					<option value="1">JSHOW</option>
+					<option value="0">JHIDE</option>
+				</field>
+			</fieldset>
+
+		</fields>
+	</config>
+</extension>


### PR DESCRIPTION
Consente la creazione di un articolo impaginato con una tabella dei contenuti.

### Summary of Changes

### Testing Instructions
Disabilitare il plugin Content - Page Break ed abilitare il plugin Content - Page Break for ItaliaPA
Creare un articolo suddiviso in pagine utilizzando il pulsante pagebreak.

### Expected result
La tabella dei contenuti è in formato compatibile con il webtoolkit

### Actual result

### Documentation Changes Required
