### PR TITLE
Module schema.org - content.prepare

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 .settings
 .buildpath
 .project
+files/
+images/
 
 # Windows image file caches
 Thumbs.db

--- a/templates/italiapa/html/com_content/featured/heronews.php
+++ b/templates/italiapa/html/com_content/featured/heronews.php
@@ -5,7 +5,7 @@
  *
  * @author		Helios Ciancio <info@eshiol.it>
  * @link		http://www.eshiol.it
- * @copyright	Copyright (C) 2017 Helios Ciancio. All Rights Reserved
+ * @copyright	Copyright (C) 2017, 2018 Helios Ciancio. All Rights Reserved
  * @license		http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3
  * Template ItaliaPA is free software. This version may have been modified
  * pursuant to the GNU General Public License, and as distributed it includes
@@ -33,6 +33,7 @@ see <a href="https://italia.github.io/design-web-toolkit/components/detail/hero-
 <section <?php echo ($this->pageclass_sfx ? 'class="'.$this->pageclass_sfx.'" ' : ''); ?>itemscope itemtype="https://schema.org/Blog">
 	<div class="Hero">
 	<?php
+	if ($this->lead_items) :
 		$item = $this->lead_items[0];
 		$images = json_decode($item->images);
 		$document = JFactory::getDocument();
@@ -76,6 +77,7 @@ see <a href="https://italia.github.io/design-web-toolkit/components/detail/hero-
 			<span class="u-padding-r-left Icon Icon-expand"></span></a>
 			<?php endif; ?>
 		</div>
+	<?php endif; ?>
 	</div>
 
 <?php 

--- a/templates/italiapa/html/mod_schemaorg/default.php
+++ b/templates/italiapa/html/mod_schemaorg/default.php
@@ -1,25 +1,25 @@
 <?php
 /**
- * @version		3.7.1 modules/mod_schemaorg/tmpl/default.php
+ * @version		3.8.0 modules/mod_schemaorg/tmpl/default.php
  *
- * @package		Template Italia PA
+ * @package		Template ItaliaPA
  * @subpackage	mod_schemaorg
  * @since		3.7
  *
  * @author		Helios Ciancio <info@eshiol.it>
  * @link		http://www.eshiol.it
- * @copyright	Copyright (C) 2017 Helios Ciancio. All Rights Reserved
+ * @copyright	Copyright (C) 2017, 2018 Helios Ciancio. All Rights Reserved
  * @license		http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3
- * Template Italia PA is free software. This version may have been modified
+ * Template ItaliaPA is free software. This version may have been modified
  * pursuant to the GNU General Public License, and as distributed it includes
- * or or is derivative of works licensed under the GNU General Public License or or
+ * or is derivative of works licensed under the GNU General Public License or
  * other free or open source software licenses.
  */
 
 defined('_JEXEC') or die;
 JLog::add(new JLogEntry(__FILE__, JLog::DEBUG, 'mod_schemaorg'));
 
-$text = '<div class="Footer-subBlock">';
+$text = '';
 if ($section = $params->get('section'))
 {
 	$text .= '<h3 class="Footer-subTitle">'.$section.'</h3>';
@@ -101,6 +101,7 @@ if (in_array($previous, $postalAddress))
 	$text .= '</div>';
 }
 
-$text .= '</address></div>';
+$text .= '</address>';
 
-echo $text;
+echo $params->get('prepare_content', 0) ? JHtml::_('content.prepare', $text) : $text;
+

--- a/templates/italiapa/html/modules.php
+++ b/templates/italiapa/html/modules.php
@@ -5,7 +5,7 @@
  *
  * @author		Helios Ciancio <info@eshiol.it>
  * @link		http://www.eshiol.it
- * @copyright	Copyright (C) 2017 Helios Ciancio. All Rights Reserved
+ * @copyright	Copyright (C) 2017, 2018 Helios Ciancio. All Rights Reserved
  * @license		http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3
  * Template ItaliaPA is free software. This version may have been modified
  * pursuant to the GNU General Public License, and as distributed it includes
@@ -67,8 +67,8 @@ function modChrome_lg($module, &$params, &$attribs)
 	$moduleClass1 = !empty($moduleClass1) ? ' class="' . htmlspecialchars($moduleClass1, ENT_COMPAT, 'UTF-8') . '"' : '';
 	$headerClass = !empty($headerClass) ? ' class="' . htmlspecialchars($headerClass, ENT_COMPAT, 'UTF-8') . '"' : '';
 
-	$plainPositions = ['footermenu','news'];
-	$plainModules = ['mod_carousel'];
+	$plainPositions = array('footermenu', 'news');
+	$plainModules = array('mod_carousel');
 
 	if (!empty($module->content))
 	{

--- a/templates/italiapa/templateDetails.xml
+++ b/templates/italiapa/templateDetails.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension version="3.0" type="template" method="upgrade">
   <name>italiapa</name>
-  <creationDate>November 2017</creationDate>
+  <creationDate>January 2018</creationDate>
   <author>Helios Ciancio</author>
-  <copyright>Copyright © 2017 Helios Ciancio (eshiol.it). All rights reserved.</copyright>
+  <copyright>Copyright © 2017, 2018 Helios Ciancio (eshiol.it). All rights reserved.</copyright>
   <authorEmail>info@eshiol.it</authorEmail>
   <authorUrl>https://www.eshiol.it</authorUrl>
-  <version>3.8.0.3</version>
+  <version>3.8.0.5</version>
   <description><![CDATA[
 		<h1>Template ItaliaPA for Joomla! 3.8</h1>
 		<p>Implementazione delle


### PR DESCRIPTION
### Summary of Changes
Corretto 

### Testing Instructions
Creare un modulo Schema.org con indirizzi email
Attivare il plugin Content - Email Cloaking

### Expected result
Le email del modulo schema.org sono cliccabili
