### PR TITLE
TinyMCE Editor - toggle button editor yes/no

### DIFF
--- a/templates/italiapa/html/layouts/joomla/tinymce/togglebutton.php
+++ b/templates/italiapa/html/layouts/joomla/tinymce/togglebutton.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @package		Template ItaliaPA
+ * @subpackage	tpl_italiapa
+ *
+ * @author		Helios Ciancio <info@eshiol.it>
+ * @link		http://www.eshiol.it
+ * @copyright	Copyright (C) 2017, 2018 Helios Ciancio. All Rights Reserved
+ * @license		http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3
+ * Template ItaliaPA is free software. This version may have been modified
+ * pursuant to the GNU General Public License, and as distributed it includes
+ * or is derivative of works licensed under the GNU General Public License or
+ * other free or open source software licenses.
+ */
+
+defined('JPATH_BASE') or die;
+
+$name = $displayData;
+
+?>
+<div class="toggle-editor btn-toolbar pull-right clearfix">
+	<button type="button" class="Button Button--default u-text-r-xs"
+		onclick="tinyMCE.execCommand('mceToggleEditor', false, '<?php echo $name; ?>');return false;"
+		title="<?php echo JText::_('PLG_TINY_BUTTON_TOGGLE_EDITOR'); ?>"
+		><?php echo JText::_('PLG_TINY_BUTTON_TOGGLE_EDITOR'); ?></button>
+</div>
+	


### PR DESCRIPTION
Pull Request for Issue #99 .

### Summary of Changes
Aggiunto toggle button editor yes/no a tinymce editor

### Testing Instructions
Accedere in modifica/inserimento articolo con un utente che ha TinyMCE Editor come editor attivo.

### Expected result
Il pulsante Editor Sì/No ha la formattazione dei pulsanti del toolkit
![image](https://user-images.githubusercontent.com/12718836/36390851-b4d4899e-15a4-11e8-9374-121f617376f6.png)
