### PR TITLE
Modulo menu - layout entrypoint - icone

### DIFF
--- a/modules/mod_schemaorg/mod_schemaorg.xml
+++ b/modules/mod_schemaorg/mod_schemaorg.xml
@@ -7,7 +7,7 @@
   <license>http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3</license>
   <authorEmail>info@eshiol.it</authorEmail>
   <authorUrl>www.eshiol.it</authorUrl>
-  <version>3.8.1.21</version>
+  <version>3.8.1.22</version>
   <description>mod_schemaorg_xml_description</description>
   <updateservers>
     <server type="extension" priority="2" name="Italia Template - Schema.org Module">https://www.eshiol.it/files/italiapa/mod_schemaorg.xml</server>
@@ -26,11 +26,10 @@
   <config>
     <fields name="params">
       <fieldset name="basic">
-      	<field name="prepare_content" type="radio" label="MOD_SCHEMAORG_FIELD_PREPARE_CONTENT_LABEL" description="MOD_SCHEMAORG_FIELD_PREPARE_CONTENT_DESC" class="btn-group btn-group-yesno" default="0">
+        <field name="prepare_content" type="radio" label="MOD_SCHEMAORG_FIELD_PREPARE_CONTENT_LABEL" description="MOD_SCHEMAORG_FIELD_PREPARE_CONTENT_DESC" class="btn-group btn-group-yesno" default="0">
           <option value="1">JYES</option>
           <option value="0">JNO</option>
-       </field>
-      
+        </field>
         <field name="section" type="text" label="MOD_SCHEMAORG_SECTION_LABEL" description="MOD_SCHEMAORG_SECTION_DESC"/>
         <field name="data" type="subform" formsource="/modules/mod_schemaorg/item.xml" label="MOD_SCHEMAORG_ITEM_LABEL" description="MOD_SCHEMAORG_ITEM_DESC" multiple="true" layout="joomla.form.field.subform.repeatable-table"/>
       </fieldset>

--- a/templates/italiapa/html/mod_menu/entrypoint.php
+++ b/templates/italiapa/html/mod_menu/entrypoint.php
@@ -94,10 +94,29 @@ if ($tagId = $params->get('tag_id', ''))
 	{
 		$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 		echo '<div class="Entrypoint-item '.($item->level == 1 ? 'u-sizeFill ' : '') .($moduleclass_sfx ? $moduleclass_sfx : 'u-background-compl-80').'"><p>';
+
+		$icon = '';
+		if ($item->anchor_css)
+		{
+			JLog::add(new JLogEntry('anchor_css: '.print_r($item->anchor_css, true), JLog::DEBUG, 'tpl_italiapa'));
+			$anchor_css = explode(' ', $item->anchor_css);
+			for($i = 0; $i < count($anchor_css); $i++)
+			{
+				if (substr($anchor_css[$i], 0, 4) == 'Icon')
+				{
+					$icon = $icon . ' ' . $anchor_css[$i];
+					unset($anchor_css[$i]);
+				}
+			}
+			// $item->anchor_css = (substr($item->anchor_css, 0, 1) == ' ' ? ' ' : '') . implode(' ', $anchor_css);
+			$item->anchor_css = implode(' ', $anchor_css);
+		}		
 		if (!$item->anchor_css)
 		{
 			$item->anchor_css = 'u-textClean u-text-h3 u-color-white';
 		}
+		$item->anchor_css .= $icon;
+		
 		switch ($item->type) :
 		case 'separator':
 		case 'component':

--- a/templates/italiapa/templateDetails.xml
+++ b/templates/italiapa/templateDetails.xml
@@ -22,6 +22,7 @@
     <folder>css</folder>
     <folder>fields</folder>
     <folder>html</folder>
+    <folder>src</folder>
     <filename>js/accordion.min.js</filename>
     <filename>js/drop.min.js</filename>
     <filename>js/map.min.js</filename>


### PR DESCRIPTION
Pull Request for Issue #118 .

### Summary of Changes
Aggiunto supporto gestione icone menu layout entrypoint

### Testing Instructions
Creare un menu con layout entrypoint; i menu in posizione featured hanno di default il layout entrypoint
Aggiungere una delle classi icone previste dal [toolkit ](https://italia.github.io/design-web-toolkit/components/detail/icons.html)ad una voce di menu
![italiapa0024](https://user-images.githubusercontent.com/12718836/36794046-89985fec-1c9f-11e8-84cf-0ccf6d091fe3.png)

### Expected result
Menu con icona e stile di default
![italiapa0025](https://user-images.githubusercontent.com/12718836/36794073-a0ae7f22-1c9f-11e8-974c-81bd5060803e.png)
