### PR TITLE
Rimozione + da link nell'header

### DIFF
--- a/templates/italiapa/index.php
+++ b/templates/italiapa/index.php
@@ -138,7 +138,7 @@ JLog::add(new JLogEntry('Template ItaliaPA', JLog::DEBUG, 'tpl_italiapa'));
 		}
 		$links[] = $x;
 	}
-	echo implode('<span class="u-color-white">&nbsp;+&nbsp;</span>', $links) . '&nbsp;';
+	echo implode('<span class="u-color-white">&nbsp;&nbsp;&nbsp;</span>', $links) . '&nbsp;';
 	?>	
 	<?php if ($this->countModules('languages')) : ?>
 		<div class="Header-languages ">


### PR DESCRIPTION
### Summary of Changes
Rimozione del "+" come separatore tra i link presenti nella barra header.
Il + è usato da Developers/Designers Italia come a significare la collaborazione tra AgID ed il Team Digitale.
Nel caso delle altre PA può sembrare fuorviante avere "Governo Italiano" + "Ministero Pubblica Istruzione".
Questa PR sostituisce il "+" con un altro spazio vuoto, così da non creare confusione nei link composti da più parole (avanti singolo spazio a divisione delle stesse).
