### PR TITLE
Owner menu

### DIFF
--- a/templates/italiapa/fields/links.xml
+++ b/templates/italiapa/fields/links.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<form>
-  <field name="title" type="text" label="TPL_ITALIAPA_LINK_TITLE_LABEL" description="TPL_ITALIAPA_LINK_TITLE_DESC"/>
-  <field name="short" type="text" label="TPL_ITALIAPA_LINK_SHORT_LABEL" description="TPL_ITALIAPA_LINK_SHORT_DESC"/>
-  <field name="href"  type="url"  label="TPL_ITALIAPA_LINK_HREF_LABEL"  description="TPL_ITALIAPA_LINK_HREF_DESC"/>
-</form>

--- a/templates/italiapa/html/mod_menu/owner.php
+++ b/templates/italiapa/html/mod_menu/owner.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * @package		Template ItaliaPA
+ * @subpackage	tpl_italiapa
+ *
+ * @author		Helios Ciancio <info@eshiol.it>
+ * @link		http://www.eshiol.it
+ * @copyright	Copyright (C) 2017 - 2019 Helios Ciancio. All Rights Reserved
+ * @license		http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3
+ * Template ItaliaPA is free software. This version may have been modified
+ * pursuant to the GNU General Public License, and as distributed it includes
+ * or is derivative of works licensed under the GNU General Public License or
+ * other free or open source software licenses.
+ */
+
+defined('_JEXEC') or die;
+
+JLog::add(new JLogEntry(__FILE__, JLog::DEBUG, 'tpl_italiapa'));
+JLog::add(new JLogEntry($module->position, JLog::DEBUG, 'tpl_italiapa'));
+
+$id = '';
+
+if ($tagId = $params->get('tag_id', ''))
+{
+	$id = ' id="' . $tagId . '"';
+}
+
+// The menu class is deprecated. Use nav instead
+?>
+<?php foreach ($list as $i => &$item)
+{
+	$class = 'item-' . $item->id;
+
+	if ($item->id == $default_id)
+	{
+		$class .= ' default';
+	}
+
+	if ($item->id == $active_id || ($item->type === 'alias' && $item->params->get('aliasoptions') == $active_id))
+	{
+		$class .= ' current';
+	}
+
+	if (in_array($item->id, $path))
+	{
+		$class .= ' active';
+	}
+	elseif ($item->type === 'alias')
+	{
+		$aliasToId = $item->params->get('aliasoptions');
+
+		if (count($path) > 0 && $aliasToId == $path[count($path) - 1])
+		{
+			$class .= ' active';
+		}
+		elseif (in_array($aliasToId, $path))
+		{
+			$class .= ' alias-parent-active';
+		}
+	}
+
+	if ($item->type === 'separator')
+	{
+		$class .= ' divider';
+	}
+
+	if ($item->deeper)
+	{
+		$class .= ' deeper';
+	}
+
+	if ($item->parent)
+	{
+		$class .= ' parent';
+	}
+
+	switch ($item->type) :
+		case 'separator':
+		case 'component':
+		case 'heading':
+		case 'url':
+			require JModuleHelper::getLayoutPath('mod_menu', 'owner_' . $item->type);
+			break;
+
+		default:
+			require JModuleHelper::getLayoutPath('mod_menu', 'owner_url');
+			break;
+	endswitch;
+}
+?>

--- a/templates/italiapa/html/mod_menu/owner_component.php
+++ b/templates/italiapa/html/mod_menu/owner_component.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * @package		Template ItaliaPA
+ * @subpackage	tpl_italiapa
+ *
+ * @author		Helios Ciancio <info@eshiol.it>
+ * @link		http://www.eshiol.it
+ * @copyright	Copyright (C) 2017 - 2019 Helios Ciancio. All Rights Reserved
+ * @license		http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3
+ * Template ItaliaPA is free software. This version may have been modified
+ * pursuant to the GNU General Public License, and as distributed it includes
+ * or is derivative of works licensed under the GNU General Public License or
+ * other free or open source software licenses.
+ */
+defined('_JEXEC') or die();
+
+JLog::add(new JLogEntry(__FILE__, JLog::DEBUG, 'tpl_italiapa'));
+JLog::add(new JLogEntry($module->position, JLog::DEBUG, 'tpl_italiapa'));
+
+$attributes = array();
+
+if ($item->anchor_title)
+{
+	$attributes['title'] = $item->anchor_title;
+	$linktype = '<span class="u-inline u-md-hidden u-lg-hidden u-sm-hidden">' . $item->title .
+			 '</span><span class="u-hidden u-md-inline u-lg-inline u-sm-inline">' . $item->anchor_title . '</span>';
+}
+else
+{
+	$linktype = $item->title;
+}
+
+if ($item->anchor_css)
+{
+	$attributes['class'] = $item->anchor_css;
+}
+
+if ($item->anchor_rel)
+{
+	$attributes['rel'] = $item->anchor_rel;
+}
+
+if ($item->menu_image)
+{
+	if ($item->menu_image_css)
+	{
+		$image_attributes['class'] = $item->menu_image_css;
+		$linktype = JHtml::_('image', $item->menu_image, $item->title, $image_attributes);
+	}
+	else
+	{
+		$linktype = JHtml::_('image', $item->menu_image, $item->title);
+	}
+	
+	if ($item->params->get('menu_text', 1))
+	{
+		$linktype .= '<span class="image-title">' . $item->title . '</span>';
+	}
+}
+
+if ($item->browserNav == 1)
+{
+	$attributes['target'] = '_blank';
+}
+elseif ($item->browserNav == 2)
+{
+	$options = 'toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes';
+	
+	$attributes['onclick'] = "window.open(this.href, 'targetWindow', '" . $options . "'); return false;";
+}
+
+echo JHtml::_('link', JFilterOutput::ampReplace(htmlspecialchars($item->flink, ENT_COMPAT, 'UTF-8', false)), $linktype, $attributes);

--- a/templates/italiapa/html/mod_menu/owner_heading.php
+++ b/templates/italiapa/html/mod_menu/owner_heading.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @package		Template ItaliaPA
+ * @subpackage	tpl_italiapa
+ *
+ * @author		Helios Ciancio <info@eshiol.it>
+ * @link		http://www.eshiol.it
+ * @copyright	Copyright (C) 2017 - 2019 Helios Ciancio. All Rights Reserved
+ * @license		http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3
+ * Template ItaliaPA is free software. This version may have been modified
+ * pursuant to the GNU General Public License, and as distributed it includes
+ * or is derivative of works licensed under the GNU General Public License or
+ * other free or open source software licenses.
+ */
+defined('_JEXEC') or die();
+
+JLog::add(new JLogEntry(__FILE__, JLog::DEBUG, 'tpl_italiapa'));
+JLog::add(new JLogEntry($module->position, JLog::DEBUG, 'tpl_italiapa'));
+
+$title = $item->anchor_title ? ' title="' . $item->anchor_title . '"' : '';
+$anchor_css = $item->anchor_css ?: '';
+
+if ($item->anchor_title)
+{
+	$linktype = '<span class="u-inline u-md-hidden u-lg-hidden u-sm-hidden">' . $item->title .
+			 '</span><span class="u-hidden u-md-inline u-lg-inline u-sm-inline">' . $item->anchor_title . '</span>';
+}
+else
+{
+	$linktype = $item->title;
+}
+
+if ($item->menu_image)
+{
+	if ($item->menu_image_css)
+	{
+		$image_attributes['class'] = $item->menu_image_css;
+		$linktype = JHtml::_('image', $item->menu_image, $item->title, $image_attributes);
+	}
+	else
+	{
+		$linktype = JHtml::_('image', $item->menu_image, $item->title);
+	}
+	
+	if ($item->params->get('menu_text', 1))
+	{
+		$linktype .= '<span class="image-title">' . $item->title . '</span>';
+	}
+}
+
+?>
+<span class="nav-header <?php echo $anchor_css; ?>"
+	<?php echo $title; ?>><?php echo $linktype; ?></span>

--- a/templates/italiapa/html/mod_menu/owner_separator.php
+++ b/templates/italiapa/html/mod_menu/owner_separator.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @package		Template ItaliaPA
+ * @subpackage	tpl_italiapa
+ *
+ * @author		Helios Ciancio <info@eshiol.it>
+ * @link		http://www.eshiol.it
+ * @copyright	Copyright (C) 2017 - 2019 Helios Ciancio. All Rights Reserved
+ * @license		http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3
+ * Template ItaliaPA is free software. This version may have been modified
+ * pursuant to the GNU General Public License, and as distributed it includes
+ * or is derivative of works licensed under the GNU General Public License or
+ * other free or open source software licenses.
+ */
+defined('_JEXEC') or die();
+
+JLog::add(new JLogEntry(__FILE__, JLog::DEBUG, 'tpl_italiapa'));
+JLog::add(new JLogEntry($module->position, JLog::DEBUG, 'tpl_italiapa'));
+
+$title = $item->anchor_title ? ' title="' . $item->anchor_title . '"' : '';
+$anchor_css = $item->anchor_css ?: '';
+
+if ($item->anchor_title)
+{
+	$linktype = '<span class="u-inline u-md-hidden u-lg-hidden u-sm-hidden">' . $item->title .
+			 '</span><span class="u-hidden u-md-inline u-lg-inline u-sm-inline">' . $item->anchor_title . '</span>';
+}
+else
+{
+	$linktype = $item->title;
+}
+
+if ($item->menu_image)
+{
+	if ($item->menu_image_css)
+	{
+		$image_attributes['class'] = $item->menu_image_css;
+		$linktype = JHtml::_('image', $item->menu_image, $item->title, $image_attributes);
+	}
+	else
+	{
+		$linktype = JHtml::_('image', $item->menu_image, $item->title);
+	}
+	
+	if ($item->params->get('menu_text', 1))
+	{
+		$linktype .= '<span class="image-title">' . $item->title . '</span>';
+	}
+}
+
+?>
+<span class="separator <?php echo $anchor_css; ?>" <?php echo $title; ?>><?php echo $linktype; ?></span>

--- a/templates/italiapa/html/mod_menu/owner_url.php
+++ b/templates/italiapa/html/mod_menu/owner_url.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * @package		Template ItaliaPA
+ * @subpackage	tpl_italiapa
+ *
+ * @author		Helios Ciancio <info@eshiol.it>
+ * @link		http://www.eshiol.it
+ * @copyright	Copyright (C) 2017 - 2019 Helios Ciancio. All Rights Reserved
+ * @license		http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3
+ * Template ItaliaPA is free software. This version may have been modified
+ * pursuant to the GNU General Public License, and as distributed it includes
+ * or is derivative of works licensed under the GNU General Public License or
+ * other free or open source software licenses.
+ */
+defined('_JEXEC') or die();
+
+JLog::add(new JLogEntry(__FILE__, JLog::DEBUG, 'tpl_italiapa'));
+JLog::add(new JLogEntry($module->position, JLog::DEBUG, 'tpl_italiapa'));
+
+$attributes = array();
+
+if ($item->anchor_title)
+{
+	$attributes['title'] = $item->anchor_title;
+	$linktype = '<span class="u-inline u-md-hidden u-lg-hidden u-sm-hidden">' . $item->title .
+			 '</span><span class="u-hidden u-md-inline u-lg-inline u-sm-inline">' . $item->anchor_title . '</span>';
+}
+else
+{
+	$linktype = $item->title;
+}
+
+if ($item->anchor_css)
+{
+	$attributes['class'] = $item->anchor_css;
+}
+
+if ($item->anchor_rel)
+{
+	$attributes['rel'] = $item->anchor_rel;
+}
+
+if ($item->menu_image)
+{
+	if ($item->menu_image_css)
+	{
+		$image_attributes['class'] = $item->menu_image_css;
+		$linktype = JHtml::_('image', $item->menu_image, $item->title, $image_attributes);
+	}
+	else
+	{
+		$linktype = JHtml::_('image', $item->menu_image, $item->title);
+	}
+	
+	if ($item->params->get('menu_text', 1))
+	{
+		$linktype .= '<span class="image-title">' . $item->title . '</span>';
+	}
+}
+
+if ($item->browserNav == 1)
+{
+	$attributes['target'] = '_blank';
+	$attributes['rel'] = 'noopener noreferrer';
+	
+	if ($item->anchor_rel == 'nofollow')
+	{
+		$attributes['rel'] .= ' nofollow';
+	}
+}
+elseif ($item->browserNav == 2)
+{
+	$options = 'toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,' . $params->get('window_open');
+	
+	$attributes['onclick'] = "window.open(this.href, 'targetWindow', '" . $options . "'); return false;";
+}
+
+echo JHtml::_('link', JFilterOutput::ampReplace(htmlspecialchars($item->flink, ENT_COMPAT, 'UTF-8', false)), $linktype, $attributes);

--- a/templates/italiapa/index.php
+++ b/templates/italiapa/index.php
@@ -120,26 +120,12 @@ JLog::add(new JLogEntry('Template ItaliaPA', JLog::DEBUG, 'tpl_italiapa'));
 
 <header class="Header u-hiddenPrint<?php if ($this->params->get('headroom', 0)) echo ' Headroom--fixed js-Headroom Headroom Headroom--top Headroom--not-bottom" style="position: fixed; top: 0px;'; ?>">
 
-<?php if ($this->params->get('links') || ($this->countModules('languages'))) : ?>
+<?php if ($this->countModules('owner') || $this->countModules('languages')) : ?>
 <div class="Header-banner">
 	<div class="Header-owner Headroom-hideme">
-	<?php 
-	$links = array();
-	foreach($this->params->get('links', array()) as $item) {
-		$x = '';
-		if ($item->short) {
-			$x .= '<span class="u-inline u-md-hidden u-lg-hidden u-sm-hidden">'. $item->short . '</span>';
-		}
-		if ($item->title) {
-			$x .= '<span class="u-hidden u-md-inline u-lg-inline u-sm-inline">' . $item->title. '</span>';
-		}
-		if ($item->href) {
-			$x = '<a href="' . $item->href . '">' . $x . '</a>';
-		}
-		$links[] = $x;
-	}
-	echo implode('<span class="u-color-white">&nbsp;+&nbsp;</span>', $links) . '&nbsp;';
-	?>	
+	<?php if ($this->countModules('owner')) : ?>
+		<jdoc:include type="modules" name="owner" />
+	<?php endif; ?> 
 	<?php if ($this->countModules('languages')) : ?>
 		<div class="Header-languages ">
 			<jdoc:include type="modules" name="languages" />

--- a/templates/italiapa/templateDetails.xml
+++ b/templates/italiapa/templateDetails.xml
@@ -20,7 +20,6 @@
   <files>
     <folder>build</folder>
     <folder>css</folder>
-    <folder>fields</folder>
     <folder>html</folder>
     <folder>src</folder>
     <filename>js/accordion.min.js</filename>
@@ -61,6 +60,7 @@
     <position>mainmenu</position>
     <position>menu</position>
     <position>news</position>
+    <position>owner</position>
     <position>right</position>
     <position>search</position>
     <position>services</position>
@@ -84,7 +84,6 @@
         </field>
       </fieldset>
       <fieldset name="header" type="upload_func" label="Header">
-        <field name="links" type="subform" formsource="templates/italiapa/fields/links.xml" label="TPL_ITALIAPA_FIELD_LINKS_LABEL" description="TPL_ITALIAPA_FIELD_LINKS_DESC" multiple="true" layout="joomla.form.field.subform.repeatable-table"/>
         <field name="logo" type="media" label="TPL_ITALIAPA_FIELD_LOGO_LABEL" description="TPL_ITALIAPA_FIELD_LOGO_LABEL"/>
         <field name="subtitle" type="text" label="TPL_ITALIAPA_FIELD_SUBTITLE_LABEL" description="TPL_ITALIAPA_FIELD_SUBTITLE_LABEL"/>
         <field name="headroom" type="radio" class="btn-group btn-group-yesno" default="0" description="TPL_ITALIAPA_DEBUG_HEADROOM_DESC" label="TPL_ITALIAPA_DEBUG_HEADROOM_LABEL">


### PR DESCRIPTION
### Summary of Changes
Aggiunta zona owner
Aggiunto layout owner a modulo menu
Rimossi link da template

### Testing Instructions
Creare un menu e aggiungere il corrispondente modulo in zona owner con layout owner
Per ogni voce di menu
![image](https://user-images.githubusercontent.com/12718836/53129447-d603fd00-3567-11e9-9950-1f4ff6a7f252.png)
impostare l'attributo Title del link
![image](https://user-images.githubusercontent.com/12718836/53129422-c4baf080-3567-11e9-8eb4-2afd9160f060.png)
In posizione owner con layout owner, verrà visualizzato il titolo su mobile e l'attributo Title del link su desktop

### Expected result
![image](https://user-images.githubusercontent.com/12718836/53129570-35620d00-3568-11e9-9702-2e6777fe4780.png)
![image](https://user-images.githubusercontent.com/12718836/53129553-267b5a80-3568-11e9-90ea-894288979ddd.png)

### Actual result

### Documentation Changes Required
Con questo aggiornamento vengono eliminati i link associati al template presenti nell'angolo alto a sinistra della pagina. Vanno quindi sostituiti da un menu in posizione owner con layout owner.