### PR TITLE
Modulo Newsflash - read more

### DIFF
--- a/templates/italiapa/html/mod_articles_news/_card.php
+++ b/templates/italiapa/html/mod_articles_news/_card.php
@@ -61,19 +61,8 @@ $assocParam = (JLanguageAssociations::isEnabled() && $item->params->get('show_as
 
 						echo $item->afterDisplayContent;
 
-						if ($params->get('show_readmore') && $this->item->readmore) :
-							if ($params->get('access-view')) :
-								$link = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language));
-							else :
-								$menu = JFactory::getApplication()->getMenu();
-								$active = $menu->getActive();
-								$itemId = $active->id;
-								$link = new JUri(JRoute::_('index.php?option=com_users&view=login&Itemid=' . $itemId, false));
-								$link->setVar('return', base64_encode(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language)));
-							endif;
-
-							echo JLayoutHelper::render('joomla.content.readmore', array('item' => $this->item, 'params' => $params, 'link' => $link));
-
+						if (isset($item->link) && $item->readmore != 0 && $params->get('readmore')) :
+							echo '<a class="readmore" href="' . $item->link . '">' . $item->linkText . '</a>';
 						endif;
 						?>
 						</div>

--- a/templates/italiapa/html/mod_articles_news/_cell.php
+++ b/templates/italiapa/html/mod_articles_news/_cell.php
@@ -55,18 +55,8 @@ $assocParam = (JLanguageAssociations::isEnabled() && $item->params->get('show_as
 
 						echo $item->afterDisplayContent;
 
-						if ($params->get('show_readmore') && $this->item->readmore) :
-							if ($params->get('access-view')) :
-								$link = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language));
-							else :
-								$menu = JFactory::getApplication()->getMenu();
-								$active = $menu->getActive();
-								$itemId = $active->id;
-								$link = new JUri(JRoute::_('index.php?option=com_users&view=login&Itemid=' . $itemId, false));
-								$link->setVar('return', base64_encode(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language)));
-							endif;
-
-							echo JLayoutHelper::render('joomla.content.readmore', array('item' => $this->item, 'params' => $item->params, 'link' => $link));
+						if (isset($item->link) && $item->readmore != 0 && $params->get('readmore')) :
+							echo '<a class="readmore" href="' . $item->link . '">' . $item->linkText . '</a>';
 						endif;
 						?>
 					</div>

--- a/templates/italiapa/html/mod_articles_news/default.php
+++ b/templates/italiapa/html/mod_articles_news/default.php
@@ -5,7 +5,7 @@
  *
  * @author		Helios Ciancio <info@eshiol.it>
  * @link		http://www.eshiol.it
- * @copyright	Copyright (C) 2017 Helios Ciancio. All Rights Reserved
+ * @copyright	Copyright (C) 2017 - 2019 Helios Ciancio. All Rights Reserved
  * @license		http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3
  * Template ItaliaPA is free software. This version may have been modified
  * pursuant to the GNU General Public License, and as distributed it includes
@@ -16,71 +16,8 @@
 defined('_JEXEC') or die;
 JLog::add(new JLogEntry(__FILE__, JLog::DEBUG, 'tpl_italiapa'));
 
-JFactory::getLanguage()->load('com_content');
-
 if ($module->position == 'featured') :
-?>
-<div class="u-layout-centerContent u-background-grey-20 <?php echo $moduleclass_sfx; ?>">
-	<section class="u-layout-wide u-padding-top-xxl u-padding-bottom-xxl">
-		<h2 id="news<?php echo $module->id?>" class="u-text-r-l u-padding-r-bottom">
-			<a class="u-color-50 u-textClean u-text-h3 " href=""><?php echo $module->title; ?></a>
-		</h2>
-
-		<div class="Grid Grid--withGutter">
-
-			<?php
-			if (($n = json_decode($module->params)->bootstrap_size) == 0)
-			{
-				// minimo 4 cells massimo 6 per riga
-				$n = min(6, max(4, count($list)));
-			}
-			foreach ($list as $item) : ?>
-			<div class="Grid-cell u-md-size1of<?php echo $n; ?> u-lg-size1of<?php echo $n; ?>">
-				<?php require JModuleHelper::getLayoutPath('mod_articles_news', '_cell'); ?>
-			</div>
-			<?php endforeach; ?>
-
-		</div>
-		<?php
-		$catid = json_decode($module->params)->catid;
-		if (is_array($catid = json_decode($module->params)->catid) && (count($catid) == 1)) {
-			$link = JRoute::_(ContentHelperRoute::getCategoryRoute($catid[0]));
-			echo JLayoutHelper::render('eshiol.content.readall', array('params' => $params, 'link' => $link));
-		}
-		?>
-	</section>
-</div>
-<?php elseif ($module->position == 'news') : ?>
-<div class="u-background-compl-10 u-layout-centerContent u-padding-r-top <?php echo $moduleclass_sfx; ?>">
-
-	<section class="u-layout-wide u-layout-r-withGutter u-text-r-s u-padding-r-top u-padding-r-bottom">
-
-		<h2 id="news<?php echo $module->id?>" class="u-layout-centerLeft u-text-r-s">
-			<a class="u-color-50 u-textClean u-text-h3 " href=""><?php echo $module->title; ?></a>
-		</h2>
-
-		<div class="Grid Grid--withGutterM">
-
-			<?php
-			if (($n = json_decode($module->params)->bootstrap_size) == 0)
-			{
-				// minimo 3 cards massimo 6 per riga
-				$n = min(6, max(3, count($list)));
-			}
-			foreach ($list as $item) : ?>
-			<div class="Grid-cell u-md-size1of<?php echo $n; ?> u-lg-size1of<?php echo $n; ?> u-flex u-margin-r-bottom u-flexJustifyCenter">
-				<?php require JModuleHelper::getLayoutPath('mod_articles_news', '_card'); ?>
-			</div>
-			<?php endforeach; ?>
-
-		</div>
-		<?php
-		$catid = json_decode($module->params)->catid;
-		if (is_array($catid = json_decode($module->params)->catid) && (count($catid) == 1)) {
-			$link = JRoute::_(ContentHelperRoute::getCategoryRoute($catid[0]));
-			echo JLayoutHelper::render('eshiol.content.readall', array('params' => $params, 'link' => $link));
-		}
-		?>
-	</section>
-</div>
-<?php endif; ?>
+	require 'featured.php';
+else : //if ($module->position == 'news') :
+	require 'focus.php';
+endif;

--- a/templates/italiapa/html/mod_articles_news/featured.php
+++ b/templates/italiapa/html/mod_articles_news/featured.php
@@ -5,7 +5,7 @@
  *
  * @author		Helios Ciancio <info@eshiol.it>
  * @link		http://www.eshiol.it
- * @copyright	Copyright (C) 2017 - 2019 Helios Ciancio. All Rights Reserved
+ * @copyright	Copyright (C) 2017 -2019 Helios Ciancio. All Rights Reserved
  * @license		http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3
  * Template ItaliaPA is free software. This version may have been modified
  * pursuant to the GNU General Public License, and as distributed it includes
@@ -15,26 +15,25 @@
 
 defined('_JEXEC') or die;
 JLog::add(new JLogEntry(__FILE__, JLog::DEBUG, 'tpl_italiapa'));
-JLog::add(new JLogEntry(print_r($params, true), JLog::DEBUG, 'tpl_italiapa'));
 
 JFactory::getLanguage()->load('com_content');
 ?>
-<div class="u-background-compl-10 u-layout-centerContent u-padding-r-top <?php echo $moduleclass_sfx; ?>">
-	<section class="u-layout-wide u-layout-r-withGutter u-text-r-s u-padding-r-top u-padding-r-bottom">
-		<h2 id="news<?php echo $module->id?>" class="u-layout-centerLeft u-text-r-s">
+<div class="u-layout-centerContent u-background-grey-20 <?php echo $moduleclass_sfx; ?>">
+	<section class="u-layout-wide u-padding-top-xxl u-padding-bottom-xxl">
+		<h2 id="news<?php echo $module->id?>" class="u-text-r-l u-padding-r-bottom">
 			<a class="u-color-50 u-textClean u-text-h3 " href=""><?php echo $module->title; ?></a>
 		</h2>
 
-		<div class="Grid Grid--withGutterM">
+		<div class="Grid Grid--withGutter">
 			<?php
 			if (($n = $params->get('bootstrap_size', 0)) == 0)
 			{
-				// minimo 3 cards massimo 6 per riga
-				$n = min(6, max(3, count($list)));
+				// minimo 4 cells massimo 6 per riga
+				$n = min(6, max(4, count($list)));
 			}
 			foreach ($list as $item) : ?>
-			<div class="Grid-cell u-md-size1of<?php echo $n; ?> u-lg-size1of<?php echo $n; ?> u-flex u-margin-r-bottom u-flexJustifyCenter">
-				<?php require JModuleHelper::getLayoutPath('mod_articles_news', '_card'); ?>
+			<div class="Grid-cell u-md-size1of<?php echo $n; ?> u-lg-size1of<?php echo $n; ?>">
+				<?php require JModuleHelper::getLayoutPath('mod_articles_news', '_cell'); ?>
 			</div>
 			<?php endforeach; ?>
 		</div>


### PR DESCRIPTION
### Summary of Changes
Corretto bug che impediva di visualizzare il link leggi tutto per singolo articolo.
Aggiunta possibilità di nascondere il link leggi tutto a fondo modulo operando sull'opzione Mostra separatore per ultimo

### Testing Instructions
Creare un modulo di tipo Newsflash.
Disabilitare l'opzione Mostra separatore per ultimo.
Abilitare l'opzione Link leggi tutto.

### Expected result
Presenza del link leggi tutto sul singolo articolo.
Mancanza del link leggi tutto a fondo modulo.

### Actual result
Mancanza del link leggi tutto sul singolo articolo.
Presenza del link leggi tutto a fondo modulo.

### Documentation Changes Required
