### PR TITLE
voce titolo separatore in menu burger

### DIFF
--- a/templates/italiapa/html/mod_menu/treeview.php
+++ b/templates/italiapa/html/mod_menu/treeview.php
@@ -5,7 +5,7 @@
  *
  * @author		Helios Ciancio <info@eshiol.it>
  * @link		http://www.eshiol.it
- * @copyright	Copyright (C) 2017, 2018 Helios Ciancio. All Rights Reserved
+ * @copyright	Copyright (C) 2017 - 2019 Helios Ciancio. All Rights Reserved
  * @license		http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3
  * Template ItaliaPA is free software. This version may have been modified
  * pursuant to the GNU General Public License, and as distributed it includes
@@ -25,18 +25,6 @@ if ($tagId = $params->get('tag_id', ''))
     $id = ' id="' . $tagId . '"';
 }
 if (!isset($maxlevel)) $maxlevel = 1;
-/**
- $tmp_class_sfx = explode(' ', $class_sfx);
- for($i = 0; $i < count($tmp_class_sfx); $i++)
- {
- if (substr($tmp_class_sfx[$i], 0, 6) == 'level:')
- {
- $maxlevel = (int)substr($tmp_class_sfx[$i], 6);
- unset($tmp_class_sfx[$i]);
- }
- }
- $class_sfx = implode(' ', $tmp_class_sfx);
- */
 if (empty($class_sfx))
 {
     $class_sfx = 'Treeview--default';
@@ -96,9 +84,12 @@ $level = 1;
 	switch ($item->type) :
 		case 'separator':
 		case 'component':
-		case 'heading':
 		case 'url':
 			require JModuleHelper::getLayoutPath('mod_menu', 'default_' . $item->type);
+			break;
+		
+		case 'heading':
+			require JModuleHelper::getLayoutPath('mod_menu', 'treeview_' . $item->type);
 			break;
 
 		default:

--- a/templates/italiapa/html/mod_menu/treeview_heading.php
+++ b/templates/italiapa/html/mod_menu/treeview_heading.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @package		Template ItaliaPA
+ * @subpackage	tpl_italiapa
+ *
+ * @author		Helios Ciancio <info@eshiol.it>
+ * @link		http://www.eshiol.it
+ * @copyright	Copyright (C) 2017 - 2019 Helios Ciancio. All Rights Reserved
+ * @license		http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3
+ * Template ItaliaPA is free software. This version may have been modified
+ * pursuant to the GNU General Public License, and as distributed it includes
+ * or is derivative of works licensed under the GNU General Public License or
+ * other free or open source software licenses.
+ */
+defined('_JEXEC') or die();
+
+JLog::add(new JLogEntry(__FILE__, JLog::DEBUG, 'tpl_italiapa'));
+
+require_once JPATH_BASE . '/templates/italiapa/src/html/iwt.php';
+
+$item->flink = '#';
+$attributes = JHtml::_('iwt.getLinkAttributes', $item);
+
+echo JHtml::_('link', JFilterOutput::ampReplace(htmlspecialchars($item->flink, ENT_COMPAT, 'UTF-8', false)), JHtml::_('iwt.linkType', $item), $attributes);
+?>


### PR DESCRIPTION
Pull Request for Issue #189.

### Summary of Changes
Corretta voce di menu di tipo Titolo separatore nel menu burger.

### Testing Instructions
Crea una voce di menu di tipo Titolo separatore nel menu burger. Aprire il sito in modalità mobile.

### Expected result
![image](https://user-images.githubusercontent.com/12718836/57539620-2c086580-734b-11e9-86e0-f001bdb53c32.png)

### Actual result
![image](https://user-images.githubusercontent.com/12718836/57539608-26128480-734b-11e9-85d5-aebb5d7e160e.png)

### Documentation Changes Required

