### PR TITLE
Colore Titolo articoli senza link

### DIFF
--- a/templates/italiapa/html/com_content/archive/default_items.php
+++ b/templates/italiapa/html/com_content/archive/default_items.php
@@ -46,7 +46,7 @@ $size = 'size' . (int) (12 / $columns) . 'of12';
 						<?php echo $this->escape($item->title); ?>
 					</a>
 				<?php else : ?>
-					<span class="u-text-h4 u-textClean u-color-black">
+					<span class="u-text-h4 u-linkClean u-color-black">
 						<?php echo $this->escape($item->title); ?>
 					</span>
 				<?php endif; ?>

--- a/templates/italiapa/html/com_content/category/blog_tile.php
+++ b/templates/italiapa/html/com_content/category/blog_tile.php
@@ -45,7 +45,9 @@ $assocParam = (JLanguageAssociations::isEnabled() && $params->get('show_associat
 			<?php echo $this->escape($this->item->title); ?>
 		</a>
 	<?php else : ?>
-		<span class="u-text-h4 u-textClean u-color-black"><?php echo $this->escape($this->item->title); ?></span>
+		<span class="u-text-h4 u-linkClean u-color-black">
+			<?php echo $this->escape($this->item->title); ?>
+		</span>
 	<?php endif; ?>
 	</h3>
 <?php endif; ?>

--- a/templates/italiapa/html/com_content/category/grid_lead.php
+++ b/templates/italiapa/html/com_content/category/grid_lead.php
@@ -47,11 +47,13 @@ $useDefList			  = ($params->get('show_modify_date') || $params->get('show_publis
 							<?php if ($params->get('show_title')) : ?>
 							<h3 class="u-padding-r-top u-padding-r-bottom" itemprop="headline">
 								<?php if ($params->get('link_titles') && $params->get('access-view')) : ?>
-								<a class="u-text-h4 u-textClean u-color-black" href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language)); ?>" itemprop="url">
-									<?php echo $this->escape($this->item->title); ?>
-								</a>
+									<a class="u-text-h4 u-textClean u-color-black" href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language)); ?>" itemprop="url">
+										<?php echo $this->escape($this->item->title); ?>
+									</a>
 								<?php else : ?>
-								<?php echo $this->escape($this->item->title); ?>
+									<span class="u-text-h4 u-linkClean u-color-black">
+										<?php echo $this->escape($this->item->title); ?>
+									</span>
 								<?php endif; ?>
 							</h3>
 							<?php endif; ?>

--- a/templates/italiapa/html/com_content/category/grid_tile.php
+++ b/templates/italiapa/html/com_content/category/grid_tile.php
@@ -47,7 +47,9 @@ $useDefList = ($params->get('show_modify_date') || $params->get('show_publish_da
 			<?php echo $this->escape($this->item->title); ?>
 		</a>
 	<?php else : ?>
-		<?php echo $this->escape($this->item->title); ?>
+		<span class="u-text-h4 u-linkClean u-color-black">
+			<?php echo $this->escape($this->item->title); ?>
+		</span>
 	<?php endif; ?>
 	</h3>
 <?php endif; ?>

--- a/templates/italiapa/html/com_content/featured/default_tile.php
+++ b/templates/italiapa/html/com_content/featured/default_tile.php
@@ -47,7 +47,9 @@ $useDefList = ($params->get('show_modify_date') || $params->get('show_publish_da
 			<?php echo $this->escape($this->item->title); ?>
 		</a>
 	<?php else : ?>
-		<?php echo $this->escape($this->item->title); ?>
+		<span class="u-text-h4 u-linkClean u-color-black">
+			<?php echo $this->escape($this->item->title); ?>
+		</span>
 	<?php endif; ?>
 	</h3>
 <?php endif; ?>

--- a/templates/italiapa/html/com_content/featured/grid_lead.php
+++ b/templates/italiapa/html/com_content/featured/grid_lead.php
@@ -47,11 +47,13 @@ $useDefList			  = ($params->get('show_modify_date') || $params->get('show_publis
 							<?php if ($params->get('show_title')) : ?>
 							<h3 class="u-padding-r-top u-padding-r-bottom" itemprop="headline">
 								<?php if ($params->get('link_titles') && $params->get('access-view')) : ?>
-								<a class="u-text-h4 u-textClean u-color-black" href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language)); ?>" itemprop="url">
-									<?php echo $this->escape($this->item->title); ?>
-								</a>
+									<a class="u-text-h4 u-textClean u-color-black" href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language)); ?>" itemprop="url">
+										<?php echo $this->escape($this->item->title); ?>
+									</a>
 								<?php else : ?>
-								<?php echo $this->escape($this->item->title); ?>
+									<span class="u-text-h4 u-linkClean u-color-black">
+										<?php echo $this->escape($this->item->title); ?>
+									</span>
 								<?php endif; ?>
 							</h3>
 							<?php endif; ?>

--- a/templates/italiapa/html/com_content/featured/grid_tile.php
+++ b/templates/italiapa/html/com_content/featured/grid_tile.php
@@ -47,7 +47,9 @@ $useDefList = ($params->get('show_modify_date') || $params->get('show_publish_da
 			<?php echo $this->escape($this->item->title); ?>
 		</a>
 	<?php else : ?>
-		<?php echo $this->escape($this->item->title); ?>
+		<span class="u-text-h4 u-linkClean u-color-black">
+			<?php echo $this->escape($this->item->title); ?>
+		</span>
 	<?php endif; ?>
 	</h3>
 <?php endif; ?>

--- a/templates/italiapa/html/com_content/featured/heronews_item.php
+++ b/templates/italiapa/html/com_content/featured/heronews_item.php
@@ -45,7 +45,9 @@ $assocParam = (JLanguageAssociations::isEnabled() && $params->get('show_associat
 			<?php echo $this->escape($this->item->title); ?>
 		</a>
 	<?php else : ?>
-		<?php echo $this->escape($this->item->title); ?>
+		<span class="u-text-h4 u-linkClean u-color-black">
+			<?php echo $this->escape($this->item->title); ?>
+		</span>
 	<?php endif; ?>
 	</h3>
 <?php endif; ?> 


### PR DESCRIPTION
Pull Request for Issue #224 .

### Summary of Changes
Corretto colore titolo articoli senza link.

### Testing Instructions
Assegnare alla voce di menù "Home" il layout "Articoli in evidenza di tutte le categorie"
Settare la voce di menù con 4 articoli principali, 4 articoli introduttivi, 4 colonne e 2 link.
Creare diversi articoli in evidenza ad accesso "registered"

### Expected result
Il titolo degli articoli introduttivi per "registered" ha la stessa formattazione degli articoli per "public"
