### PR TITLE
Modulo Newsflash - layout Carousel

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_system_italiapa.ini
+++ b/administrator/language/en-GB/en-GB.plg_system_italiapa.ini
@@ -1,0 +1,23 @@
+; Joomla.Plugins.System.ItaliaPA
+; Copyright (C) 2017 - 2020 Helios Ciancio. All rights reserved.
+; License GNU General Public License version 3 or later; see LICENSE
+; Note : All ini files need to be saved as UTF-8
+
+PLG_SYSTEM_ITALIAPA_CAROUSEL_AUTO_SLIDING_DESC="If enabled, the carousel is animated starting at page load."
+PLG_SYSTEM_ITALIAPA_CAROUSEL_AUTO_SLIDING_LABEL="Auto sliding"
+PLG_SYSTEM_ITALIAPA_CAROUSEL_LAYOUT_DESC=""
+PLG_SYSTEM_ITALIAPA_CAROUSEL_LAYOUT_LABEL="Item layout"
+PLG_SYSTEM_ITALIAPA_CAROUSEL_LAYOUT_CARD="Card"
+PLG_SYSTEM_ITALIAPA_CAROUSEL_LAYOUT_CELL="Cell"
+PLG_SYSTEM_ITALIAPA_CAROUSEL_COUNT_DESC="The number of images to display on each slide (the default is 1)."
+PLG_SYSTEM_ITALIAPA_CAROUSEL_COUNT_LABEL="# of Images"
+PLG_SYSTEM_ITALIAPA_CAROUSEL_LAZY_DESC=""
+PLG_SYSTEM_ITALIAPA_CAROUSEL_LAZY_LABEL="Lazy"
+PLG_SYSTEM_ITALIAPA_CAROUSEL_INTERVAL_DESC="Specifies the amount of time to delay (in milliseconds) between one slide to another in automatic cycling."
+PLG_SYSTEM_ITALIAPA_CAROUSEL_INTERVAL_LABEL="Interval"
+PLG_SYSTEM_ITALIAPA_CAROUSEL_SHOW_CONTROLS_DESC="Adds a left button and a right one to the carousel, which allow the user to go back and forth between the slides."
+PLG_SYSTEM_ITALIAPA_CAROUSEL_SHOW_CONTROLS_LABEL="Show controls"
+PLG_SYSTEM_ITALIAPA_CAROUSEL_SHOW_INDICATORS_DESC="Adds indicators for the carousel. These are the little dots at the bottom of each slide (which indicates how many slides there are in the carousel, and which slide the user are currently viewing)."
+PLG_SYSTEM_ITALIAPA_CAROUSEL_SHOW_INDICATORS_LABEL="Show indicators"
+PLG_SYSTEM_ITALIAPA_CAROUSEL_SPEED_DESC="Specifies the time (in milliseconds) a transition effect takes to complete."
+PLG_SYSTEM_ITALIAPA_CAROUSEL_SPEED_LABEL="Speed"

--- a/administrator/language/en-GB/en-GB.plg_system_italiapa.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_system_italiapa.sys.ini
@@ -1,0 +1,7 @@
+; Joomla.Plugins.System.ItaliaPA
+; Copyright (C) 2017 - 2020 Helios Ciancio. All rights reserved.
+; License GNU General Public License version 3 or later; see LICENSE
+; Note : All ini files need to be saved as UTF-8
+
+PLG_SYSTEM_ITALIAPA="System - ItaliaPA"
+PLG_SYSTEM_ITALIAPA_XML_DESCRIPTION=""

--- a/administrator/language/it-IT/it-IT.plg_system_italiapa.ini
+++ b/administrator/language/it-IT/it-IT.plg_system_italiapa.ini
@@ -1,0 +1,23 @@
+; Joomla.Plugins.System.ItaliaPA
+; Copyright (C) 2017 - 2020 Helios Ciancio. All rights reserved.
+; License GNU General Public License version 3 or later; see LICENSE
+; Note : All ini files need to be saved as UTF-8
+
+PLG_SYSTEM_ITALIAPA_CAROUSEL_AUTO_SLIDING_DESC="Se abilitato, il carousel sarà animato al caricamento della pagina."
+PLG_SYSTEM_ITALIAPA_CAROUSEL_AUTO_SLIDING_LABEL="Scorrimento automatico"
+PLG_SYSTEM_ITALIAPA_CAROUSEL_LAYOUT_DESC=""
+PLG_SYSTEM_ITALIAPA_CAROUSEL_LAYOUT_LABEL="Layout diapositiva"
+PLG_SYSTEM_ITALIAPA_CAROUSEL_LAYOUT_CARD="Card"
+PLG_SYSTEM_ITALIAPA_CAROUSEL_LAYOUT_CELL="Cell"
+PLG_SYSTEM_ITALIAPA_CAROUSEL_COUNT_DESC="Il numero di immagini da visualizzare in ogni diapositiva (il default è 1)."
+PLG_SYSTEM_ITALIAPA_CAROUSEL_COUNT_LABEL="# di immagini"
+PLG_SYSTEM_ITALIAPA_CAROUSEL_LAZY_DESC=""
+PLG_SYSTEM_ITALIAPA_CAROUSEL_LAZY_LABEL="Lazy"
+PLG_SYSTEM_ITALIAPA_CAROUSEL_INTERVAL_DESC="Specifica il ritardo (in millisecondi) tra due diapositive."
+PLG_SYSTEM_ITALIAPA_CAROUSEL_INTERVAL_LABEL="Intervallo"
+PLG_SYSTEM_ITALIAPA_CAROUSEL_SHOW_CONTROLS_DESC="Aggiunge un pulsante a sinistra e uno a destra al carosello, che consentono all'utente di andare avanti e indietro tra le diapositive."
+PLG_SYSTEM_ITALIAPA_CAROUSEL_SHOW_CONTROLS_LABEL="Mostra controlli"
+PLG_SYSTEM_ITALIAPA_CAROUSEL_SHOW_INDICATORS_DESC="Aggiunge indicatori per il carousel. Questi sono i puntini nella parte inferiore di ogni diapositiva (che indica il numero di diapositive presenti nel carousel e che l'utente sta visualizzando attualmente."
+PLG_SYSTEM_ITALIAPA_CAROUSEL_SHOW_INDICATORS_LABEL="Mostra indicatori"
+PLG_SYSTEM_ITALIAPA_CAROUSEL_SPEED_DESC="Specifica il tempo (in millisecondi) necessario per completare un effetto di transizione da una slide ad un'altra."
+PLG_SYSTEM_ITALIAPA_CAROUSEL_SPEED_LABEL="Velocità"

--- a/administrator/language/it-IT/it-IT.plg_system_italiapa.sys.ini
+++ b/administrator/language/it-IT/it-IT.plg_system_italiapa.sys.ini
@@ -1,0 +1,7 @@
+; Joomla.Plugins.System.ItaliaPA
+; Copyright (C) 2017 - 2020 Helios Ciancio. All rights reserved.
+; License GNU General Public License version 3 or later; see LICENSE
+; Note : All ini files need to be saved as UTF-8
+
+PLG_SYSTEM_ITALIAPA="System - ItaliaPA"
+PLG_SYSTEM_ITALIAPA_XML_DESCRIPTION=""

--- a/plugins/system/italiapa/forms/carousel.xml
+++ b/plugins/system/italiapa/forms/carousel.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form>
+	<fields name="params">
+		<fieldset name="advanced">
+			<field name="carousel_count" type="integer" label="PLG_SYSTEM_ITALIAPA_CAROUSEL_COUNT_LABEL" description="PLG_SYSTEM_ITALIAPA_CAROUSEL_COUNT_DESC" first="1" last="12" step="1"
+				showon="layout:italiapa:carousel" />
+			<field name="carousel_layout" type="list" label="PLG_SYSTEM_ITALIAPA_CAROUSEL_LAYOUT_LABEL" description="PLG_SYSTEM_ITALIAPA_CAROUSEL_LAYOUT_DESC"
+				showon="layout:italiapa:carousel">
+				<option value="">JDEFAULT</option>
+				<option value="_card">PLG_SYSTEM_ITALIAPA_CAROUSEL_LAYOUT_CARD</option>
+				<option value="_hcell">PLG_SYSTEM_ITALIAPA_CAROUSEL_LAYOUT_CELL</option>
+			</field>
+			<field name="carousel_show_controls" type="radio" label="PLG_SYSTEM_ITALIAPA_CAROUSEL_SHOW_CONTROLS_LABEL" description="PLG_SYSTEM_ITALIAPA_CAROUSEL_SHOW_CONTROLS_DESC" class="btn-group btn-group-yesno" default="1"
+				showon="layout:italiapa:carousel">
+				<option value="1">JSHOW</option>
+				<option value="0">JHIDE</option>
+			</field>
+			<field name="carousel_show_indicators" type="radio" label="PLG_SYSTEM_ITALIAPA_CAROUSEL_SHOW_INDICATORS_LABEL" description="PLG_SYSTEM_ITALIAPA_CAROUSEL_SHOW_INDICATORS_DESC" class="btn-group btn-group-yesno" default="1"
+				showon="layout:italiapa:carousel">
+				<option value="1">JSHOW</option>
+				<option value="0">JHIDE</option>
+			</field>
+			<field name="carousel_auto_sliding" type="radio" label="PLG_SYSTEM_ITALIAPA_CAROUSEL_AUTO_SLIDING_LABEL" description="PLG_SYSTEM_ITALIAPA_CAROUSEL_AUTO_SLIDING_DESC" class="btn-group btn-group-yesno" default="1"
+				showon="layout:italiapa:carousel">
+				<option value="1">JYES</option>
+				<option value="0">JNO</option>
+			</field>
+			<field name="carousel_interval" type="text" label="PLG_SYSTEM_ITALIAPA_CAROUSEL_INTERVAL_LABEL" description="PLG_SYSTEM_ITALIAPA_CAROUSEL_INTERVAL_DESC" default="5000" filter="integer"
+				showon="layout:italiapa:carousel[AND]carousel_auto_sliding:1" />				
+			<field name="carousel_speed" type="text" label="PLG_SYSTEM_ITALIAPA_CAROUSEL_SPEED_LABEL" description="PLG_SYSTEM_ITALIAPA_CAROUSEL_SPEED_DESC" default="1000" filter="integer"
+				showon="layout:italiapa:carousel[AND]carousel_auto_sliding:1" />				
+			<field name="carousel_lazy" type="radio" label="PLG_SYSTEM_ITALIAPA_CAROUSEL_LAZY_LABEL" description="PLG_SYSTEM_ITALIAPA_CAROUSEL_LAZY_DESC" class="btn-group btn-group-yesno" default="1"
+				showon="layout:italiapa:carousel">
+				<option value="1">JYES</option>
+				<option value="0">JNO</option>
+			</field>
+		</fieldset>
+	</fields>
+</form>

--- a/plugins/system/italiapa/italiapa.php
+++ b/plugins/system/italiapa/italiapa.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * @package     Joomla.Plugins
+ * @subpackage  System.ItaliaPA
+ *
+ * @author		Helios Ciancio <info (at) eshiol (dot) it>
+ * @link		http://www.eshiol.it
+ * @copyright	Copyright (C) 2017 - 2020 Helios Ciancio. All Rights Reserved
+ * @license		http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3
+ * Template ItaliaPA is free software. This version may have been modified
+ * pursuant to the GNU General Public License, and as distributed it includes
+ * or is derivative of works licensed under the GNU General Public License or
+ * other free or open source software licenses.
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Form\Form;
+
+/**
+ * Joomla! ItaliaPA Plugin.
+ *
+ * @since  3.9.0
+ */
+class PlgSystemItaliaPA extends JPlugin
+{
+	/**
+	 * Application object.
+	 *
+	 * @var    JApplicationCms
+	 * @since  3.9.0
+	 */
+	protected $app;
+
+	/**
+	 * Database object.
+	 *
+	 * @var    JDatabaseDriver
+	 * @since  3.9.0
+	 */
+	protected $db;
+
+	/**
+	 * Load plugin language file automatically so that it can be used inside component
+	 *
+	 * @var    boolean
+	 * @since  3.9.0
+	 */
+	protected $autoloadLanguage = true;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param   object  &$subject  The object to observe.
+	 * @param   array   $config    An optional associative array of configuration settings.
+	 *
+	 * @since   3.9.0
+	 */
+	public function __construct(&$subject, $config)
+	{
+		parent::__construct($subject, $config);
+	}
+
+	/**
+	 * Adds additional fields to the Newsflash module
+	 *
+	 * @param   JForm  $form  The form to be altered.
+	 * @param   mixed  $data  The associated data for the form.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   3.9.0
+	 */
+	public function onContentPrepareForm($form, $data)
+	{
+		if (!$form instanceof Form)
+		{
+			$this->subject->setError('JERROR_NOT_A_FORM');
+
+			return false;
+		}
+
+		$formName = $form->getName();
+
+		if ($formName == 'com_modules.module')
+		{
+			// If we are on the save command, no data is passed to $data variable, we need to get it directly from request
+			$jformData = $this->app->input->get('jform', array(), 'array');
+
+			if ($jformData && !$data)
+			{
+				$data = $jformData;
+			}
+
+			if (is_array($data))
+			{
+				$data = (object) $data;
+			}
+			
+			Form::addFormPath(dirname(__FILE__) . '/forms');
+
+			if ($data->module == 'mod_articles_news')
+			{
+				Form::addFormPath(dirname(__FILE__) . '/forms');
+				
+				$form->loadFile('carousel', false);
+			}
+		}
+	}
+}

--- a/plugins/system/italiapa/italiapa.xml
+++ b/plugins/system/italiapa/italiapa.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extension version="3.9" type="plugin" group="system" method="upgrade">
+	<name>plg_system_italiapa</name>
+	<author>Helios Ciancio</author>
+	<creationDate>February 2020</creationDate>
+	<copyright>(C) 2017 - 2020 Helios Ciancio. All rights reserved.</copyright>
+	<license>http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3</license>
+	<authorEmail>info@eshiol.it</authorEmail>
+	<authorUrl>www.eshiol.it</authorUrl>
+	<version>3.9.0</version>
+	<description>PLG_SYSTEM_ITALIAPA_XML_DESCRIPTION</description>
+	<files>
+		<filename plugin="italiapa">italiapa.php</filename>
+		<folder>forms</folder>
+	</files>
+	<languages>
+		<language tag="en-GB">en-GB.plg_system_italiapa.ini</language>
+		<language tag="en-GB">en-GB.plg_system_italiapa.sys.ini</language>
+		<language tag="it-IT">it-IT.plg_system_italiapa.ini</language>
+		<language tag="it-IT">it-IT.plg_system_italiapa.sys.ini</language>
+	</languages>
+</extension>

--- a/templates/italiapa/html/mod_articles_news/_hcell.php
+++ b/templates/italiapa/html/mod_articles_news/_hcell.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * @package		Joomla.Site
+ * @subpackage	Templates.ItaliaPA
+ *
+ * @author		Helios Ciancio <info (at) eshiol (dot) it>
+ * @link		http://www.eshiol.it
+ * @copyright	Copyright (C) 2017 - 2020 Helios Ciancio. All Rights Reserved
+ * @license		http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3
+ * Template ItaliaPA is free software. This version may have been modified
+ * pursuant to the GNU General Public License, and as distributed it includes
+ * or is derivative of works licensed under the GNU General Public License or
+ * other free or open source software licenses.
+ */
+
+defined('_JEXEC') or die;
+
+$info = $item->params->get('info_block_position', 0);
+
+// Check if associations are implemented. If they are, define the parameter.
+$assocParam = (JLanguageAssociations::isEnabled() && $item->params->get('show_associations'));
+?>
+<?php $images = json_decode($item->images); ?>
+<?php if (($params->get('img_intro_full') == 'intro') && isset($images->image_intro) && !empty($images->image_intro)) : ?>
+	<div class="Carousel-item Grid">
+		<div class="Grid-cell u-sizeFull u-md-size1of2 u-lg-size1of2 u-text-r-s u-padding-r-all">
+			<?php echo JLayoutHelper::render('joomla.content.intro_image', $item); ?>
+		</div>
+		<div class="Grid-cell u-sizeFull u-md-size1of2 u-lg-size1of2 u-text-r-s u-padding-r-all">
+<?php elseif (($params->get('img_intro_full') == 'full') && isset($images->image_full) && !empty($images->image_full)) : ?>
+	<div class="Carousel-item Grid">
+		<div class="Grid-cell u-sizeFull u-md-size1of2 u-lg-size1of2 u-text-r-s u-padding-r-all">
+			<?php echo JLayoutHelper::render('joomla.content.full_image', $item); ?>
+		</div>
+		<div class="Grid-cell u-sizeFull u-md-size1of2 u-lg-size1of2 u-text-r-s u-padding-r-all">
+<?php endif; ?>
+		<div class="u-color-grey-30 u-border-top-xxs u-padding-right-xxl u-padding-r-all">
+			<?php
+			$useDefList = ($item->params->get('show_modify_date') || $item->params->get('show_publish_date') || $item->params->get('show_create_date') || $item->params->get('show_hits') || $item->params->get('show_category') || $item->params->get('show_parent_category') || $item->params->get('show_author') || $assocParam);
+
+			if ($useDefList && ($info == 0 || $info == 2)) :
+				echo JLayoutHelper::render('joomla.content.info_block', array('item' => $item, 'params' => $item->params, 'position' => 'above'));
+			endif;
+			?>
+
+			<?php if ($params->get('item_title')) : ?>
+			<h3 class="u-padding-r-top u-padding-r-bottom">
+				<?php if ($item->link !== '' && $params->get('link_titles')) : ?>
+				<a class="u-text-h4 u-textClean u-color-black" href="<?php echo $item->link; ?>">
+					<?php echo $item->title; ?>
+				</a>
+				<?php else : ?>
+					<span class="u-text-h4 u-textClean u-color-black"><?php echo $item->title; ?></span>
+				<?php endif; ?>
+			</h3>
+			<?php endif; ?>
+
+			<div class="u-lineHeight-l u-text-r-xs u-textSecondary u-padding-r-right">
+				<?php
+				if (!$params->get('intro_only')) :
+					echo $item->afterDisplayTitle;
+				endif;
+
+				echo $item->beforeDisplayContent;
+
+				if ($params->get('show_introtext', '1')) :
+					echo $item->introtext;
+				endif;
+
+				echo $item->afterDisplayContent;
+
+				if (isset($item->link) && $item->readmore != 0 && $params->get('readmore')) :
+					echo '<a class="readmore" href="' . $item->link . '">' . $item->linkText . '</a>';
+				endif;
+				?>
+			</div>
+		</div>
+<?php if (($params->get('img_intro_full') == 'intro') && isset($images->image_intro) && !empty($images->image_intro)) : ?>
+		</div>
+	</div>
+<?php elseif (($params->get('img_intro_full') == 'full') && isset($images->image_full) && !empty($images->image_full)) : ?>
+		</div>
+	</div>
+<?php endif; ?>
+		

--- a/templates/italiapa/html/mod_articles_news/carousel.php
+++ b/templates/italiapa/html/mod_articles_news/carousel.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @package		Joomla.Site
+ * @subpackage	Templates.ItaliaPA
+ *
+ * @author		Helios Ciancio <info (at) eshiol (dot) it>
+ * @link		http://www.eshiol.it
+ * @copyright	Copyright (C) 2017 - 2020 Helios Ciancio. All Rights Reserved
+ * @license		http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3
+ * Template ItaliaPA is free software. This version may have been modified
+ * pursuant to the GNU General Public License, and as distributed it includes
+ * or is derivative of works licensed under the GNU General Public License or
+ * other free or open source software licenses.
+ */
+
+defined('_JEXEC') or die;
+
+JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
+
+JHtml::_('behavior.caption');
+?>
+
+<section class="u-text-r-s u-padding-r-top u-padding-r-bottom blog" itemscope itemtype="https://schema.org/Blog">
+	<div class="owl-carousel news-theme" role="region" id="carousel-<?php echo $module->id; ?>"
+		aria-label="carousel-<?php echo $module->title; ?>"
+		data-carousel-options='{"items":<?php echo $params->get('carousel_count', 1);
+		echo $params->get('carousel_auto_sliding', 1) ? ',"autoplay":true,"autoplaySpeed":' . $params->get('carousel_speed', 1000) . ',"autoplayTimeout":' . $params->get('carousel_interval', 5000) : '';
+		echo $params->get('carousel_lazy', 1) ? ',"lazyLoad":true' : '';
+		echo $params->get('carousel_loop', 1) ? ',"loop":true' : '';
+		echo $params->get('carousel_show_controls', 1) ? ',"nav":true' : '';
+		echo $params->get('carousel_show_indicators', 1) ? ',"dots":true' : ''; ?>,"responsive":false}'>
+		<?php foreach ($list as $item) : ?>
+			<div<?php echo $item->state == 0 ? ' class=\"system-unpublished\"' : null; ?> itemprop="blogPost" itemscope itemtype="https://schema.org/BlogPosting">
+				<?php require JModuleHelper::getLayoutPath('mod_articles_news', $params->get('carousel_layout', ($module->position == 'right' || $params->get('carousel_count', 1) > 1) ? '_card' : '_hcell')); ?>
+			</div>
+		<?php endforeach; ?>
+	</div>
+</section>


### PR DESCRIPTION
### Summary of Changes
Aggiunto il layout Carousel al modulo Newsflash

### Testing Instructions
Installare il plugin System - ItaliaPA e creare un modulo newsflash con layout Carousel
![screencapture-localhost-pasw-italiapasw14-administrator-index-php-2020-02-05-17_45_41](https://user-images.githubusercontent.com/12718836/73866036-73714300-4844-11ea-8698-c1c9d38c5235.png)

### Expected result
![screencapture-localhost-pasw-italiapasw14-index-php-moduli-newsflash-2020-02-05-17_50_06](https://user-images.githubusercontent.com/12718836/73866068-8126c880-4844-11ea-9647-351df1b9294c.png)
![screencapture-localhost-pasw-italiapasw14-index-php-moduli-newsflash-2020-02-05-17_50_06_2](https://user-images.githubusercontent.com/12718836/73866092-8ab03080-4844-11ea-952c-093da2b4d3e8.png)
![screencapture-localhost-pasw-italiapasw14-index-php-moduli-newsflash-2020-02-05-17_50_06_3](https://user-images.githubusercontent.com/12718836/73866097-8dab2100-4844-11ea-8d7e-d5852e1594d4.png)

### Actual result



### Documentation Changes Required

