### PR TITLE
Articoli - Categoria blog - opzioni carousel

### DIFF
--- a/plugins/system/italiapa/forms/com_content_category_blog.xml
+++ b/plugins/system/italiapa/forms/com_content_category_blog.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form>
+	<fields name="params">
+		<fieldset name="advanced">
+			<field type="spacer" hr="true"/>
+			<field name="carousel_show_controls" type="radio" label="PLG_SYSTEM_ITALIAPA_CAROUSEL_SHOW_CONTROLS_LABEL" description="PLG_SYSTEM_ITALIAPA_CAROUSEL_SHOW_CONTROLS_DESC" class="btn-group btn-group-yesno" default="1">
+				<option value="1">JSHOW</option>
+				<option value="0">JHIDE</option>
+			</field>
+			<field name="carousel_show_indicators" type="radio" label="PLG_SYSTEM_ITALIAPA_CAROUSEL_SHOW_INDICATORS_LABEL" description="PLG_SYSTEM_ITALIAPA_CAROUSEL_SHOW_INDICATORS_DESC" class="btn-group btn-group-yesno" default="1">
+				<option value="1">JSHOW</option>
+				<option value="0">JHIDE</option>
+			</field>
+			<field name="carousel_auto_sliding" type="radio" label="PLG_SYSTEM_ITALIAPA_CAROUSEL_AUTO_SLIDING_LABEL" description="PLG_SYSTEM_ITALIAPA_CAROUSEL_AUTO_SLIDING_DESC" class="btn-group btn-group-yesno" default="1">
+				<option value="1">JYES</option>
+				<option value="0">JNO</option>
+			</field>
+			<field name="carousel_interval" type="text" label="PLG_SYSTEM_ITALIAPA_CAROUSEL_INTERVAL_LABEL" description="PLG_SYSTEM_ITALIAPA_CAROUSEL_INTERVAL_DESC" default="5000" filter="integer"
+				showon="carousel_auto_sliding:1" />
+			<field name="carousel_speed" type="text" label="PLG_SYSTEM_ITALIAPA_CAROUSEL_SPEED_LABEL" description="PLG_SYSTEM_ITALIAPA_CAROUSEL_SPEED_DESC" default="1000" filter="integer"
+				showon="carousel_auto_sliding:1" />
+			<field name="carousel_lazy" type="radio" label="PLG_SYSTEM_ITALIAPA_CAROUSEL_LAZY_LABEL" description="PLG_SYSTEM_ITALIAPA_CAROUSEL_LAZY_DESC" class="btn-group btn-group-yesno" default="1">
+				<option value="1">JYES</option>
+				<option value="0">JNO</option>
+			</field>
+		</fieldset>
+	</fields>
+</form>

--- a/plugins/system/italiapa/italiapa.php
+++ b/plugins/system/italiapa/italiapa.php
@@ -3,13 +3,13 @@
  * @package     Joomla.Plugins
  * @subpackage  System.ItaliaPA
  *
- * @version		__DEPLOY_VERSION__
+ * @version     __DEPLOY_VERSION__
  *
- * @author		Helios Ciancio <info (at) eshiol (dot) it>
- * @link		http://www.eshiol.it
- * @copyright	Copyright (C) 2017 - 2020 Helios Ciancio. All Rights Reserved
- * @license		http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3
- * Template ItaliaPA is free software. This version may have been modified
+ * @author      Helios Ciancio <info (at) eshiol (dot) it>
+ * @link        http://www.eshiol.it
+ * @copyright   Copyright (C) 2017 - 2020 Helios Ciancio. All Rights Reserved
+ * @license     http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3
+ * Template ItaliaPA  is  free  software. This version may have been modified
  * pursuant to the GNU General Public License, and as distributed it includes
  * or is derivative of works licensed under the GNU General Public License or
  * other free or open source software licenses.
@@ -127,6 +127,27 @@ class PlgSystemItaliaPA extends JPlugin
 					}
 				}
 			}
+		}
+		elseif ($formName == 'com_menus.item')
+		{
+			// If we are on the save command, no data is passed to $data variable, we need to get it directly from request
+			$jformData = $this->app->input->get('jform', array(), 'array');
+
+			if ($jformData && !$data)
+			{
+				$data = $jformData;
+			}
+
+			if (is_array($data))
+			{
+				$data = (object) $data;
+			}
+
+			Form::addFormPath(dirname(__FILE__) . '/forms');
+			$form->loadFile(
+					$data->request['option'] . '_' .
+					$data->request['view'] . '_' .
+					$data->request['layout'], false);
 		}
 	}
 }

--- a/templates/italiapa/html/com_content/category/blog.php
+++ b/templates/italiapa/html/com_content/category/blog.php
@@ -1,15 +1,15 @@
 <?php
 /**
- * @package		Joomla.Site
- * @subpackage	Templates.ItaliaPA
+ * @package     Joomla.Plugins
+ * @subpackage  System.ItaliaPA
  *
- * @version		__DEPLOY_VERSION__
+ * @version     __DEPLOY_VERSION__
  *
- * @author		Helios Ciancio <info (at) eshiol (dot) it>
- * @link		http://www.eshiol.it
- * @copyright	Copyright (C) 2017 - 2020 Helios Ciancio. All Rights Reserved
- * @license		http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3
- * Template ItaliaPA is free software. This version may have been modified
+ * @author      Helios Ciancio <info (at) eshiol (dot) it>
+ * @link        http://www.eshiol.it
+ * @copyright   Copyright (C) 2017 - 2020 Helios Ciancio. All Rights Reserved
+ * @license     http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3
+ * Template ItaliaPA  is  free  software. This version may have been modified
  * pursuant to the GNU General Public License, and as distributed it includes
  * or is derivative of works licensed under the GNU General Public License or
  * other free or open source software licenses.
@@ -73,7 +73,14 @@ $afterDisplayContent = trim(implode("\n", $results));
 	<?php $limitstart = $app->input->get('limitstart', 0, 'uint'); ?>
 
 	<?php if ($limitstart == 0) : ?>
-		<div class="owl-carousel news-theme" role="region" id="carousel-main" data-carousel-options='{"items":1,"responsive":false,"autoplay":true,"loop":true,"dots":true,"nav":true}'>
+		<div class="owl-carousel news-theme" role="region" id="carousel-main"
+			aria-label="carousel-main"
+			data-carousel-options='{"items":1<?php 
+			echo $this->params->get('carousel_auto_sliding', 1) ? ',"autoplay":true,"autoplaySpeed":' . $this->params->get('carousel_speed', 1000) . ',"autoplayTimeout":' . $this->params->get('carousel_interval', 5000) : '';
+			echo $this->params->get('carousel_lazy', 1) ? ',"lazyLoad":true' : '';
+			echo $this->params->get('carousel_loop', 1) ? ',"loop":true' : '';
+			echo $this->params->get('carousel_show_controls', 1) ? ',"nav":true' : '';
+			echo $this->params->get('carousel_show_indicators', 1) ? ',"dots":true' : ''; ?>,"responsive":false}'>
 			<?php foreach($this->lead_items as $item) : ?>
 				<div<?php echo $item->state == 0 ? ' class=\"system-unpublished\"' : null; ?> itemprop="blogPost" itemscope itemtype="https://schema.org/BlogPosting">
 					<?php $this->item = &$item; ?>


### PR DESCRIPTION
Pull Request for Issue #256 .

### Summary of Changes
Aggiunti parametri di configurazione carousel alla voce di menu di tipo Articoli - Categoria blog
![image](https://user-images.githubusercontent.com/12718836/101566893-1c8e4a00-39d0-11eb-96e2-837ef883ecbc.png)

### Testing Instructions
Creare una voce di menu del tipo "Articoli - Categoria blog";
Impostare i parametri relativi al carousel degli articoli principali, sotto il tab Layout blog.

### Documentation Changes Required
Mostra controlli: Aggiunge un pulsante a sinistra e uno a destra al carosello, che consentono all'utente di andare avanti e indietro tra le diapositive.
Mostra indicatori: Aggiunge gli indicatori per il carousel. Questi sono i puntini nella parte inferiore di ogni diapositiva, che indica il numero di diapositive presenti nel carousel e quale l'utente sta visualizzando attualmente.
Scorrimento automatico: Se abilitato, il carousel sarà animato al caricamento della pagina.
Intervallo: Specifica il ritardo (in millisecondi) tra due diapositive. Disponibile solo se lo scorrimento automatico è attivo.
Velocità: Specifica il tempo (in millisecondi) necessario per completare un effetto di transizione da una slide ad un'altra. Disponibile solo se lo scorrimento automatico è attivo.
Lazy: Se attivo permette il caricamento asincrono delle immagini per velocizzare caricamento della pagina.

