### PR TITLE
Modulo Menu - corretto layout lead

### DIFF
--- a/templates/italiapa/html/mod_menu/lead.php
+++ b/templates/italiapa/html/mod_menu/lead.php
@@ -20,7 +20,8 @@ defined('_JEXEC') or die;
 
 <?php $id = ($tagId = $params->get('tag_id', '')) ? ' id="' . $tagId . '"' : ''; ?>
 
-<?php $class_sfx = trim(implode(' ', array_unique(explode(' ', 'Arrange-sizeFill ' . $class_sfx)))); ?>
+<?php $class_sfx = (empty($class_sfx) || (substr($class_sfx, 0, 1) == ' ') ? ' ' : '') .
+		trim(implode(' ', array_unique(explode(' ', $class_sfx . ' Arrange-sizeFill')))); ?>
 
 <ul class="Grid Grid--withGutter<?php echo $class_sfx; ?>"<?php echo $id; ?>>
 <?php $n = min(count($list), 12); ?>


### PR DESCRIPTION
### Summary of Changes
Corretta visualizzazione modulo menu con layout Lead.

### Testing Instructions
Inserire un modulo menu in posizione Lead senza alcun Suffisso classe menu. Le celle del Lead devono avere una spaziatura fissa.

### Expected result
![image](https://user-images.githubusercontent.com/12718836/101982059-b45e9300-3c71-11eb-974f-0cd409231083.png)

### Actual result
![image](https://user-images.githubusercontent.com/12718836/101982111-f982c500-3c71-11eb-9cb7-a457ec84df1a.png)
Le celle del Lead non hanno spaziatura

### Documentation Changes Required

