### PR TITLE
Tags - Lista compatta di elementi taggati - Visualizza selezione errata formattazione

### DIFF
--- a/templates/italiapa/html/com_tags/tag/list_items.php
+++ b/templates/italiapa/html/com_tags/tag/list_items.php
@@ -18,7 +18,6 @@
 defined('_JEXEC') or die;
 
 JHtml::_('behavior.core');
-JHtml::_('formbehavior.chosen', 'select');
 
 $n         = count($this->items);
 $listOrder = $this->escape($this->state->get('list.ordering'));


### PR DESCRIPTION
Pull Request for Issue #348 .

### Summary of Changes
Corretta select box Visualizza selezione.


### Testing Instructions
Creare una voce di menu di tipo Tags - Lista compatta di elementi taggati
Attivare l'opzione Lista - Visualizza selezione


### Expected result
![image](https://user-images.githubusercontent.com/12718836/102699476-5f101c00-4245-11eb-904e-655f8936a372.png)



### Actual result
![image](https://user-images.githubusercontent.com/12718836/102699479-6505fd00-4245-11eb-9d8b-9511c91292c1.png)



### Documentation Changes Required

