### PR TITLE
Modulo elenco categorie - anomalia descrizione categorie

### DIFF
--- a/templates/italiapa/html/mod_articles_categories/focus_items.php
+++ b/templates/italiapa/html/mod_articles_categories/focus_items.php
@@ -38,9 +38,9 @@ $lang  = JFactory::getLanguage();
 							<?php echo $icon . $item->title; ?>
 						</a>
 					</h3>
-					<?php if ($item->description) : ?>
+					<?php if ($params->get('show_description', 0) && $item->description) : ?>
 						<div class="u-text-p u-textSecondary">
-							<?php echo $item->description; ?>
+							<?php echo JHtml::_('content.prepare', $item->description, $item->getParams(), 'mod_articles_categories.content'); ?>
 						</div>
 					<?php endif; ?>
 				</div>


### PR DESCRIPTION
Pull Request for Issue #367 .

### Summary of Changes
Corretta opzione _descrizione categoria_

### Testing Instructions
Creare una categoria con più sottocategorie
Creare un modulo Elenco Categorie con layout focus associata alla categoria padre appena creata
Nelle impostazioni del modulo, selezionare "no" per la "descrizione categoria"


### Expected result
![image](https://user-images.githubusercontent.com/12718836/103766018-5fb6f980-501e-11eb-8728-82359d1cea3d.png)

### Actual result
![image](https://user-images.githubusercontent.com/12718836/103766023-634a8080-501e-11eb-87f7-2973ad6d9446.png)
