### PR TITLE
Content - Vote for ItaliaPA - jcfields warning

### DIFF
--- a/plugins/content/ipavote/ipavote.php
+++ b/plugins/content/ipavote/ipavote.php
@@ -112,11 +112,14 @@ class PlgContentIpavote extends JPlugin
 			$params = new \JRegistry();
 		}
 
-		foreach ($row->jcfields as $jcField)
+		if (isset($row->jcfields))
 		{
-			if (($jcField->name == 'plg-content-ipavote-position') && $jcField->rawvalue[0])
+			foreach ($row->jcfields as $jcField)
 			{
-				$params->set('vote_position', $jcField->rawvalue[0]);
+				if (($jcField->name == 'plg-content-ipavote-position') && $jcField->rawvalue[0])
+				{
+					$params->set('vote_position', $jcField->rawvalue[0]);
+				}
 			}
 		}
 
@@ -192,12 +195,15 @@ class PlgContentIpavote extends JPlugin
 
 		$style = $this->params->get('style', 'default');
 
-		foreach ($row->jcfields as $jcField)
+		if (isset($row->jcfields))
 		{
-			if (($jcField->name == 'plg-content-ipavote-style') && $jcField->rawvalue[0])
+			foreach ($row->jcfields as $jcField)
 			{
-				$style = $jcField->rawvalue[0];
-				break;
+				if (($jcField->name == 'plg-content-ipavote-style') && $jcField->rawvalue[0])
+				{
+					$style = $jcField->rawvalue[0];
+					break;
+				}
 			}
 		}
 		JLog::add(new JLogEntry('style: ' . $style, JLog::DEBUG, 'plg_content_ipavote'));


### PR DESCRIPTION
### Summary of Changes
Corretto jcfields warning nel plugin Content - Vote for ItaliaPA

### Testing Instructions
Impostare l'opzione Globale Rapporto errori a livello Sviluppo
Abilitare l'opzione Display Errors a livello di server
Installare ed abilitare il plugin Content - Vote for ItaliaPA
Aprire la pagina delle immagini. Contenuti >> Media

### Expected result
Nessun notice o warning riferibile al plugin Content - Vote for ItaliaPA

### Actual result
```
Notice: Undefined property: Joomla\CMS\Object\CMSObject::$jcfields in .../plugins/content/ipavote/ipavote.php on line 115
Warning: Invalid argument supplied for foreach() in .../plugins/content/ipavote/ipavote.php on line 115
```
### Documentation Changes Required
