### PR TITLE
SimpleXMLElement::addAttribute(): Attribute already exists

### DIFF
--- a/plugins/system/italiapa/src/joomla/joomla/form/fields/checkbox.php
+++ b/plugins/system/italiapa/src/joomla/joomla/form/fields/checkbox.php
@@ -80,7 +80,12 @@ class JFormFieldCheckbox extends _JFormFieldCheckbox
 	 */
 	public function setup(SimpleXMLElement $element, $value, $group = null)
 	{
-		$element->addAttribute('hiddenLabel', true);
+		$attributes = $element->attributes();
+		if (isset($attributes['hiddenLabel'])) {
+			$attributes->hiddenLabel = true;
+		} else {
+			$element->addAttribute('hiddenLabel', true);
+		}
 
 		return parent::setup($element, $value, $group);
 	}


### PR DESCRIPTION
### Summary of Changes
Corrtto warning: SimpleXMLElement::addAttribute(): Attribute already exists in /plugins/system/italiapa/src/joomla/joomla/form/fields/checkbox.php

### Testing Instructions
Creare una voce di menu Singolo contatto.

### Actual result
![image](https://user-images.githubusercontent.com/12718836/105169551-f8b83b00-5b1b-11eb-9871-1e20958ce865.png)
