### PR TITLE
Update templateDetails.xml

### DIFF
--- a/templates/italiapa/templateDetails.xml
+++ b/templates/italiapa/templateDetails.xml
@@ -88,7 +88,7 @@
       </fieldset>
       <fieldset name="header" type="upload_func" label="Header">
         <field name="logo" type="media" label="TPL_ITALIAPA_FIELD_LOGO_LABEL" description="TPL_ITALIAPA_FIELD_LOGO_DESC"/>
-        <field name="subtitle" type="text" label="TPL_ITALIAPA_FIELD_SUBTITLE_LABEL" description="TPL_ITALIAPA_FIELD_SUBTITLE_LABEL"/>
+        <field name="subtitle" type="text" label="TPL_ITALIAPA_FIELD_SUBTITLE_LABEL" description="TPL_ITALIAPA_FIELD_SUBTITLE_DESC"/>
         <field name="headroom" type="radio" class="btn-group btn-group-yesno" default="0" description="TPL_ITALIAPA_FIELD_HEADROOM_DESC" label="TPL_ITALIAPA_FIELD_HEADROOM_LABEL">
           <option value="1">JYES</option>
           <option value="0">JNO</option>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Corretto il valore TPL_ITALIAPA_FIELD_SUBTITLE_LABEL con TPL_ITALIAPA_FIELD_SUBTITLE_DESC per la descrizione del campo "Sottotitolo".


### Testing Instructions
Estensioni > Template > ItaliaPA - Predefinito
Clicca sulla scheda "Header"
Puntare il mouse sulla scritta "**Sottotitolo**".
Non compare la descrizione.


### Expected result
![sottotitolo-dopo](https://user-images.githubusercontent.com/3976174/106008722-e14af600-60b7-11eb-89aa-c49fe9038fb9.png)



### Actual result
![sottotitolo-prima](https://user-images.githubusercontent.com/3976174/106008754-e9a33100-60b7-11eb-883d-c0ac123d32ed.png)



### Documentation Changes Required

