### PR TITLE
Megamenu - ripristinato comportamento it web toolkit

### DIFF
--- a/templates/italiapa/html/mod_menu/megamenu.php
+++ b/templates/italiapa/html/mod_menu/megamenu.php
@@ -25,18 +25,16 @@ if (!function_exists('hierarchical_array_from_array'))
 	{
 		$tree  = array();
 		$level--;
-			foreach ($farray as &$node)
+		foreach ($farray as &$node)
 		{
 			$node->child = array();
 			$node->cols = 1;
-			$node->depth = 1;
 			$node->level -= $level;
 			$node->footer = false;
 
 			if (array_key_exists($node->parent_id, $nodes))
 			{
 				$nodes[$node->parent_id]->child[] = $node;
-				$nodes[$node->parent_id]->depth = max(array_map(function($o) { return $o->depth; }, $nodes[$node->parent_id]->child)) + 1;
 				if ($node->anchor_css)
 				{
 					$anchor_css = explode(' ', $node->anchor_css);
@@ -85,7 +83,7 @@ if (!function_exists('megamenu'))
 
 		foreach ($menu as $i => $item)
 		{
-			$class = ' item-' . $item->id;
+		    $class = ' item-' . $item->id;
 			$subclass = '';
 			if ($item->id == $default_id)
 			{
@@ -152,7 +150,7 @@ if (!function_exists('megamenu'))
 			}
 			elseif ($item->level == 2)
 			{
-				if (!$item->footer && $nodes[$item->parent_id]->depth > 2)
+				if (!$item->footer)
 				{
 					echo '<ul class="Megamenu-subnavGroup' . ($item->cols > 1 ? ' columns" data-columns="' . $item->cols : '') . '">';
 				}


### PR DESCRIPTION
### Summary of Changes
Ripristinato il comportamento di default delle voci del megamenu.

### Testing Instructions
Creare un megamenu con una voce principale con sottovici di un solo livello.
![image](https://user-images.githubusercontent.com/12718836/107055337-7d1fe480-67d1-11eb-8d50-6340838d8650.png)


### Expected result
Le voci di menu sono mostrate in orizzontale
![image](https://user-images.githubusercontent.com/12718836/107055370-86a94c80-67d1-11eb-89ff-5d6095d56130.png)


### Actual result
Le voci di menu sono mostrate in verticale, tipo dropdown
![image](https://user-images.githubusercontent.com/12718836/107055397-8c9f2d80-67d1-11eb-99e8-a3735823b1cf.png)

### Documentation Changes Required
Per avere una visualizzazione di tipo dropdown
![image](https://user-images.githubusercontent.com/12718836/107055728-e142a880-67d1-11eb-8d64-7c37b7958a99.png)

creare una voce di menu di tipo separatore che contenga le voci di menu da visualizzare.
![image](https://user-images.githubusercontent.com/12718836/107055608-c1ab8000-67d1-11eb-9df0-498ad4f30662.png)


