### PR TITLE
Corretto ordine caricamento fogli di stile

### DIFF
--- a/templates/italiapa/index.php
+++ b/templates/italiapa/index.php
@@ -35,12 +35,6 @@ if ($params->get('phpconsole') && class_exists('JLogLoggerPhpconsole'))
 }
 JLog::add(new JLogEntry('Template ItaliaPA', JLog::DEBUG, 'tpl_italiapa'));
 
-// Check for a custom CSS file
-JHtml::_('stylesheet', 'user.css', array('version' => 'auto', 'relative' => true));
-
-// Check for a custom JS file
-JHtml::_('script', 'user.js', array('version' => 'auto', 'relative' => true));
-
 $theme_default = $params->get('theme', 'italia');
 $theme = (isset($_COOKIE['theme']) && $_COOKIE['theme']) ? $_COOKIE['theme'] : $theme_default;
 $theme_path = JPATH_ROOT . '/templates/italiapa/build/build.' . $theme . '.css';


### PR DESCRIPTION
### Summary of Changes
Ripristinato il corretto ordine di carimento dei fogli di stile.

- build.css
- build._theme_.css
- user.css

### Testing Instructions
Creare un foglio di stile personalizzato user.css come descritto nella guida su https://www.eshiol.it/it/c0bc

### Expected result
Tutte le personalizzazioni sovrascrivono le impostazioni presenti nei fogli di stile build.css e build._theme_.css
