### PR TITLE
Firma circolari print

### DIFF
--- a/templates/italiapa/component.php
+++ b/templates/italiapa/component.php
@@ -19,9 +19,9 @@ defined('_JEXEC') or die;
 
 /** @var JDocumentHtml $this */
 
-$app = JFactory::getApplication();
-
+$app	= JFactory::getApplication();
 $params = $app->getTemplate(true)->params;
+$min    = '.min';
 
 if ($params->get('debug') || defined('JDEBUG') && JDEBUG)
 {
@@ -47,6 +47,23 @@ JHtml::_('script', 'jui/html5.js', array('version' => 'auto', 'relative' => true
 
 // Add Stylesheets
 JHtml::_('stylesheet', 'component.css', array('version' => 'auto', 'relative' => true));
+
+$theme_default = $params->get('theme', 'italia');
+$theme = (isset($_COOKIE['theme']) && $_COOKIE['theme']) ? $_COOKIE['theme'] : $theme_default;
+$theme_path = JPATH_ROOT . '/templates/italiapa/build/build.' . $theme . '.css';
+
+if (!file_exists($theme_path)) {
+	$theme = 'italia';
+}
+
+JFactory::getSession()->set('theme', $theme);
+
+/** @var JDocumentHtml $this */
+$this->baseurl = JURI::root();
+
+JHtml::_('stylesheet', 'templates/italiapa/build/build' . $min . '.css', array('version' => 'auto'));
+JHtml::_('stylesheet', 'templates/italiapa/build/build.' . $theme . $min . '.css', array('version' => 'auto'), array('id'=>'theme'));
+JHtml::_('stylesheet', 'italiapa' . $min . '.css', array('version' => 'auto', 'relative' => true));
 
 // Load optional rtl Bootstrap css and Bootstrap bugfixes
 JHtmlBootstrap::loadCss($includeMaincss = false, $this->direction);

--- a/templates/italiapa/html/layouts/joomla/content/icons.php
+++ b/templates/italiapa/html/layouts/joomla/content/icons.php
@@ -75,7 +75,6 @@ $class = 'Button Button--default u-text-r-xs u-linkClean';
 						$url  = ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language);
 						$url .= '&buttons=report';
 						$text = '<span data-tooltip="' . JHtml::tooltipText(JText::_('TPL_ITALIAPA_BUTTONS_REPORT'), null, 0, 0) . '" data-tooltip-position="bottom center"><span class="u-text-r-m Icon Icon-list"></span></span>';
-						$attribs['title']   = JText::_('TPL_ITALIAPA_BUTTONS_REPORT');
 						$attribs['rel']     = 'nofollow';
 						$attribs['class']   = $class;
 						echo '<li class="u-padding-right-xs">' . JHtml::_('link', JRoute::_($url), $text, $attribs) . '</li>';
@@ -85,14 +84,12 @@ $class = 'Button Button--default u-text-r-xs u-linkClean';
 				{
 					$url  = 'index.php?option=com_buttons&view=extras&id=' . $item->id . '&buttons=report&format=csv';
 					$text = '<span data-tooltip="' . JHtml::tooltipText(JText::_('TPL_ITALIAPA_BUTTONS_CSV'), null, 0, 0) . '" data-tooltip-position="bottom center"><span class="u-text-r-m Icon Icon-download"></span></span>';
-					$attribs['title']   = JText::_('TPL_ITALIAPA_BUTTONS_CSV');
 					$attribs['rel']     = 'nofollow';
 					$attribs['class']   = $class;
 					echo '<li class="u-padding-right-xs">' . JHtml::_('link', JRoute::_($url), $text, $attribs) . '</li>';
 
 					$url  = ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language);
 					$text = '<span data-tooltip="' . JHtml::tooltipText(JText::_('TPL_ITALIAPA_BUTTONS_CLOSE'), null, 0, 0) . '" data-tooltip-position="bottom center"><span class="u-text-r-m Icon Icon-close"></span></span>';
-					$attribs['title']   = JText::_('TPL_ITALIAPA_BUTTONS_CLOSE');
 					$attribs['rel']     = 'nofollow';
 					$attribs['class']   = $class;
 					echo '<li class="u-padding-right-xs">' . JHtml::_('link', JRoute::_($url), $text, $attribs) . '</li>';

--- a/templates/italiapa/html/layouts/joomla/content/icons.php
+++ b/templates/italiapa/html/layouts/joomla/content/icons.php
@@ -38,17 +38,9 @@ $class = 'Button Button--default u-text-r-xs u-linkClean';
 		<?php if ($canEdit || $displayData['params']->get('show_print_icon') || $displayData['params']->get('show_email_icon')) : ?>
 		<nav class="Navscroll u-floatRight">
 			<ul>
-			<?php // Note the actions class is deprecated. Use dropdown-menu instead. ?>
-			<?php if ($displayData['params']->get('show_print_icon')) : ?>
-				<li class="u-padding-right-xs"><?php echo preg_replace("/title=\"[\\s\\S]*?\"/", '', JHtml::_('icon.print_popup', $displayData['item'], $displayData['params'], array('class' => $class))); ?></li>
-			<?php endif; ?>
-			<?php if ($displayData['params']->get('show_email_icon')) : ?>
-				<li class="u-padding-right-xs"><?php echo JLayoutHelper::render('eshiol.content.share', $displayData); ?></li>
-			<?php endif; ?>
 
+			<?php if (JComponentHelper::getComponent('com_buttons', true)->enabled) : ?>
 			<?php
-			if (JComponentHelper::getComponent('com_buttons', true)->enabled)
-			{
 				$item = $displayData['item'];
 				$authorisedViewLevels = JFactory::getUser()->getAuthorisedViewLevels();
 				$report_access = false;
@@ -64,14 +56,25 @@ $class = 'Button Button--default u-text-r-xs u-linkClean';
 				}
 				$params = new JRegistry();
 				$params->loadString($item->attribs);
-
+				?>
+				<?php if ($displayData['params']->get('show_print_icon')) : ?>
+					<?php $button = JHtml::_('icon.print_popup', $displayData['item'], $displayData['params'], array('class' => $class)); ?>
+					<?php if (JFactory::getApplication()->input->getString('buttons') == 'report') : ?>
+						<?php $button = str_replace('&amp;tmpl=component&amp;print=1&amp;layout=default', '&amp;tmpl=component&amp;print=1&amp;layout=default&amp;buttons=report', $button); ?>
+					<?php endif; ?>
+					<li class="u-padding-right-xs"><?php echo preg_replace("/title=\"[\\s\\S]*?\"/", '', $button); ?></li>
+				<?php endif; ?>
+				<?php if ($displayData['params']->get('show_email_icon')) : ?>
+					<li class="u-padding-right-xs"><?php echo JLayoutHelper::render('eshiol.content.share', $displayData); ?></li>
+				<?php endif; ?>
+				<?php
 				if (JFactory::getApplication()->input->getString('buttons') != 'report')
 				{
 					if ($report_access)
 					{
 						$url  = ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language);
 						$url .= '&buttons=report';
-						$text = '<span class="u-text-r-m Icon Icon-list"></span>';
+						$text = '<span data-tooltip="' . JHtml::tooltipText(JText::_('TPL_ITALIAPA_BUTTONS_REPORT'), null, 0, 0) . '" data-tooltip-position="bottom center"><span class="u-text-r-m Icon Icon-list"></span></span>';
 						$attribs['title']   = JText::_('TPL_ITALIAPA_BUTTONS_REPORT');
 						$attribs['rel']     = 'nofollow';
 						$attribs['class']   = $class;
@@ -81,22 +84,28 @@ $class = 'Button Button--default u-text-r-xs u-linkClean';
 				else
 				{
 					$url  = 'index.php?option=com_buttons&view=extras&id=' . $item->id . '&buttons=report&format=csv';
-					$text = '<span class="u-text-r-m Icon Icon-download"></span>';
+					$text = '<span data-tooltip="' . JHtml::tooltipText(JText::_('TPL_ITALIAPA_BUTTONS_CSV'), null, 0, 0) . '" data-tooltip-position="bottom center"><span class="u-text-r-m Icon Icon-download"></span></span>';
 					$attribs['title']   = JText::_('TPL_ITALIAPA_BUTTONS_CSV');
 					$attribs['rel']     = 'nofollow';
 					$attribs['class']   = $class;
 					echo '<li class="u-padding-right-xs">' . JHtml::_('link', JRoute::_($url), $text, $attribs) . '</li>';
 
 					$url  = ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language);
-					$text = '<span class="u-text-r-m Icon Icon-close"></span>';
+					$text = '<span data-tooltip="' . JHtml::tooltipText(JText::_('TPL_ITALIAPA_BUTTONS_CLOSE'), null, 0, 0) . '" data-tooltip-position="bottom center"><span class="u-text-r-m Icon Icon-close"></span></span>';
 					$attribs['title']   = JText::_('TPL_ITALIAPA_BUTTONS_CLOSE');
 					$attribs['rel']     = 'nofollow';
 					$attribs['class']   = $class;
 					echo '<li class="u-padding-right-xs">' . JHtml::_('link', JRoute::_($url), $text, $attribs) . '</li>';
 				}
-			}
 			?>
-
+			<?php else: ?>
+				<?php if ($displayData['params']->get('show_print_icon')) : ?>
+					<li class="u-padding-right-xs"><?php echo preg_replace("/title=\"[\\s\\S]*?\"/", '', JHtml::_('icon.print_popup', $displayData['item'], $displayData['params'], array('class' => $class))); ?></li>
+				<?php endif; ?>
+				<?php if ($displayData['params']->get('show_email_icon')) : ?>
+					<li class="u-padding-right-xs"><?php echo JLayoutHelper::render('eshiol.content.share', $displayData); ?></li>
+				<?php endif; ?>
+			<?php endif; ?>
 			<?php if ($canEdit) : ?>
 				<li class="u-padding-right-xs"><?php echo preg_replace("/title=\"[\\s\\S]*?\"/", '', JHtml::_('icon.edit', $displayData['item'], $displayData['params'], array('class' => $class))); ?></li>
 			<?php endif; ?>

--- a/templates/italiapa/html/layouts/joomla/content/icons.php
+++ b/templates/italiapa/html/layouts/joomla/content/icons.php
@@ -74,7 +74,7 @@ $class = 'Button Button--default u-text-r-xs u-linkClean';
 					{
 						$url  = ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language);
 						$url .= '&buttons=report';
-						$text = '<span data-tooltip="' . JHtml::tooltipText(JText::_('TPL_ITALIAPA_BUTTONS_REPORT'), null, 0, 0) . '" data-tooltip-position="bottom center"><span class="u-text-r-m Icon Icon-list"></span></span>';
+						$text = '<span data-tooltip="' . JHtml::tooltipText(JText::_('TPL_ITALIAPA_BUTTONS_REPORT')) . '" data-tooltip-position="bottom center"><span class="u-text-r-m Icon Icon-list"></span></span>';
 						$attribs['rel']     = 'nofollow';
 						$attribs['class']   = $class;
 						echo '<li class="u-padding-right-xs">' . JHtml::_('link', JRoute::_($url), $text, $attribs) . '</li>';
@@ -83,13 +83,13 @@ $class = 'Button Button--default u-text-r-xs u-linkClean';
 				else
 				{
 					$url  = 'index.php?option=com_buttons&view=extras&id=' . $item->id . '&buttons=report&format=csv';
-					$text = '<span data-tooltip="' . JHtml::tooltipText(JText::_('TPL_ITALIAPA_BUTTONS_CSV'), null, 0, 0) . '" data-tooltip-position="bottom center"><span class="u-text-r-m Icon Icon-download"></span></span>';
+					$text = '<span data-tooltip="' . JHtml::tooltipText(JText::_('TPL_ITALIAPA_BUTTONS_CSV')) . '" data-tooltip-position="bottom center"><span class="u-text-r-m Icon Icon-download"></span></span>';
 					$attribs['rel']     = 'nofollow';
 					$attribs['class']   = $class;
 					echo '<li class="u-padding-right-xs">' . JHtml::_('link', JRoute::_($url), $text, $attribs) . '</li>';
 
 					$url  = ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language);
-					$text = '<span data-tooltip="' . JHtml::tooltipText(JText::_('TPL_ITALIAPA_BUTTONS_CLOSE'), null, 0, 0) . '" data-tooltip-position="bottom center"><span class="u-text-r-m Icon Icon-close"></span></span>';
+					$text = '<span data-tooltip="' . JHtml::tooltipText(JText::_('TPL_ITALIAPA_BUTTONS_CLOSE')) . '" data-tooltip-position="bottom center"><span class="u-text-r-m Icon Icon-close"></span></span>';
 					$attribs['rel']     = 'nofollow';
 					$attribs['class']   = $class;
 					echo '<li class="u-padding-right-xs">' . JHtml::_('link', JRoute::_($url), $text, $attribs) . '</li>';

--- a/templates/italiapa/html/layouts/joomla/content/icons/print_popup.php
+++ b/templates/italiapa/html/layouts/joomla/content/icons/print_popup.php
@@ -20,7 +20,7 @@ defined('JPATH_BASE') or die;
 $params = $displayData['params'];
 
 ?>
-<span data-tooltip="<?php echo JHtml::tooltipText(JText::_('JGLOBAL_PRINT'), 0); ?>" data-tooltip-position="bottom center">
+<span data-tooltip="<?php echo JHtml::tooltipText(JText::_('JGLOBAL_PRINT')); ?>" data-tooltip-position="bottom center">
 	<?php if ($params->get('show_icons')) : ?>
 		<span class="u-text-r-m Icon Icon-print"></span>
 		<span class="u-hidden"><?php echo JText::_('JGLOBAL_PRINT'); ?></span>


### PR DESCRIPTION
### Summary of Changes
Corretto pulsante print report Firma Circolari.
Corrette le etichette dei pulsanti Report, Print, CSV e Close di Firma Circolari.

### Testing Instructions
Aprire un articolo con agganciata una toolbar di Firma Circolari.

Cliccare sul pulsante Report
![issue-report](https://user-images.githubusercontent.com/12718836/148642451-37f89530-7af8-4fd4-b23d-4861c2744ea5.png)

e poi su Print
![print](https://user-images.githubusercontent.com/12718836/148642465-8af837ec-7325-44ba-a17e-0e0f14d719bb.png)

### Expected result
![pr-print](https://user-images.githubusercontent.com/12718836/148642492-1216a99c-602d-4cb5-8943-93c912cd663a.png)

### Actual result
Il pulsante print non è collegato alla pagina report ma all'articolo originario
![issue-print](https://user-images.githubusercontent.com/12718836/148642502-c2e0d73f-cbe7-4937-b2e4-57bf91e81682.png)

### Documentation Changes Required

