### PR TITLE
Megamenu - corretto campo link class

### DIFF
--- a/templates/italiapa/html/mod_menu/megamenu.php
+++ b/templates/italiapa/html/mod_menu/megamenu.php
@@ -140,10 +140,7 @@ if (!function_exists('megamenu'))
 				}
 				$item->anchor_css = (substr($item->anchor_css, 0, 1) == ' ' ? ' ' : '') . implode(' ', $anchor_css);
 			}
-			if (!$item->anchor_css)
-			{
-				$class = 'Megamenu-item' . $class;
-			}
+			$class = 'Megamenu-item' . $class;
 			if ($item->level == 1)
 			{
 				$class = ($class || $subclass ? ' class="' . $class . ' ' . $subclass . '"' : '');


### PR DESCRIPTION
### Summary of Changes
Corretto campo link class di megamenu.

### Testing Instructions
Creare una voce di menu ed impostare il campo Link Class.
![Immagine 2022-01-11 201822](https://user-images.githubusercontent.com/12718836/149020713-16f2e99d-6271-42de-9675-7f4140cba94c.png)

### Expected result
![image](https://user-images.githubusercontent.com/12718836/149020837-00aafe85-4ae9-4204-8eea-00c79bac9c45.png)

### Actual result
![image](https://user-images.githubusercontent.com/12718836/149020924-7184bf9f-51b0-42b0-ab44-c5f90aa9d556.png)

### Documentation Changes Required

