### PR TITLE
Modulo News Flash Carousel Responsive

### DIFF
--- a/plugins/system/italiapa/forms/carousel.xml
+++ b/plugins/system/italiapa/forms/carousel.xml
@@ -3,7 +3,9 @@
 	<fields name="params">
 		<fieldset name="advanced">
 			<field name="carousel_count" type="integer" label="PLG_SYSTEM_ITALIAPA_CAROUSEL_COUNT_LABEL" description="PLG_SYSTEM_ITALIAPA_CAROUSEL_COUNT_DESC" first="1" last="12" step="1"
-				showon="layout:italiapa:carousel" />
+				showon="layout:italiapa:carousel">
+				<option value="0">PLG_SYSTEM_ITALIAPA_CAROUSEL_RESPONSIVE</option>
+			</field>
 			<field name="carousel_layout" type="list" label="PLG_SYSTEM_ITALIAPA_CAROUSEL_LAYOUT_LABEL" description="PLG_SYSTEM_ITALIAPA_CAROUSEL_LAYOUT_DESC"
 				showon="layout:italiapa:carousel">
 				<option value="">JDEFAULT</option>

--- a/templates/italiapa/html/mod_articles_news/carousel.php
+++ b/templates/italiapa/html/mod_articles_news/carousel.php
@@ -27,12 +27,12 @@ JHtml::_('behavior.caption');
 	<div class="owl-carousel news-theme" role="region" id="carousel-<?php echo $module->id; ?>"
 		aria-label="carousel-<?php echo $module->title; ?>"
 		data-carousel-options='{<?php
-		echo ($count > 0) ? '"items":' . $count . ',"responsive":false' : '';
-		echo $params->get('carousel_auto_sliding', 1) ? ',"autoplay":true,"autoplaySpeed":' . $params->get('carousel_speed', 1000) . ',"autoplayTimeout":' . $params->get('carousel_interval', 5000) : '';
+		echo ($count > 0) ? '"items":' . $count . ',"responsive":false,' : '';
+		echo $params->get('carousel_auto_sliding', 1) ? '"autoplay":true,"autoplaySpeed":' . $params->get('carousel_speed', 1000) . ',"autoplayTimeout":' . $params->get('carousel_interval', 5000) : '';
 		echo $params->get('carousel_lazy', 1) ? ',"lazyLoad":true' : '';
 		echo $params->get('carousel_loop', 1) ? ',"loop":true' : '';
 		echo $params->get('carousel_show_controls', 1) ? ',"nav":true' : '';
-		echo $params->get('carousel_show_indicators', 1) ? ',"dots":true' : ''; ?>,"responsive":false}'>
+		echo $params->get('carousel_show_indicators', 1) ? ',"dots":true' : ''; ?>}'>
 		<?php foreach ($list as $item) : ?>
 			<div<?php echo $item->state == 0 ? ' class=\"system-unpublished\"' : null; ?> itemprop="blogPost" itemscope itemtype="https://schema.org/BlogPosting">
 				<?php require JModuleHelper::getLayoutPath('mod_articles_news', $params->get('carousel_layout', ($module->position == 'right' || $params->get('carousel_count', 1) > 1) ? '_card' : '_hcell')); ?>

--- a/templates/italiapa/html/mod_articles_news/carousel.php
+++ b/templates/italiapa/html/mod_articles_news/carousel.php
@@ -22,10 +22,12 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 JHtml::_('behavior.caption');
 ?>
 
+<?php $count = $params->get('carousel_count', 1); ?>
 <section class="u-text-r-s u-padding-r-top u-padding-r-bottom blog" itemscope itemtype="https://schema.org/Blog">
 	<div class="owl-carousel news-theme" role="region" id="carousel-<?php echo $module->id; ?>"
 		aria-label="carousel-<?php echo $module->title; ?>"
-		data-carousel-options='{"items":<?php echo $params->get('carousel_count', 1);
+		data-carousel-options='{<?php
+		echo ($count > 0) ? '"items":' . $count . ',"responsive":false' : '';
 		echo $params->get('carousel_auto_sliding', 1) ? ',"autoplay":true,"autoplaySpeed":' . $params->get('carousel_speed', 1000) . ',"autoplayTimeout":' . $params->get('carousel_interval', 5000) : '';
 		echo $params->get('carousel_lazy', 1) ? ',"lazyLoad":true' : '';
 		echo $params->get('carousel_loop', 1) ? ',"loop":true' : '';

--- a/templates/italiapa/html/mod_articles_news/carousel.php
+++ b/templates/italiapa/html/mod_articles_news/carousel.php
@@ -27,12 +27,36 @@ JHtml::_('behavior.caption');
 	<div class="owl-carousel news-theme" role="region" id="carousel-<?php echo $module->id; ?>"
 		aria-label="carousel-<?php echo $module->title; ?>"
 		data-carousel-options='{<?php
-		echo ($count > 0) ? '"items":' . $count . ',"responsive":false,' : '';
-		echo $params->get('carousel_auto_sliding', 1) ? '"autoplay":true,"autoplaySpeed":' . $params->get('carousel_speed', 1000) . ',"autoplayTimeout":' . $params->get('carousel_interval', 5000) : '';
-		echo $params->get('carousel_lazy', 1) ? ',"lazyLoad":true' : '';
-		echo $params->get('carousel_loop', 1) ? ',"loop":true' : '';
-		echo $params->get('carousel_show_controls', 1) ? ',"nav":true' : '';
-		echo $params->get('carousel_show_indicators', 1) ? ',"dots":true' : ''; ?>}'>
+			$options = [];
+			if ($count > 0) 
+			{
+				$options[] = '"items":' . $count;
+				$options[] = '"responsive":false';
+			}
+			if ($params->get('carousel_auto_sliding', 1))
+			{
+				$options[] = '"autoplay":true';
+				$options[] = '"autoplaySpeed":' . $params->get('carousel_speed', 1000);
+				$options[] = '"autoplayTimeout":' . $params->get('carousel_interval', 5000);
+			}
+			if ($params->get('carousel_lazy', 1))
+			{
+				$options[] = '"lazyLoad":true';
+			}
+			if ($params->get('carousel_loop', 1))
+			{
+				$options[] = '"loop":true';
+			}
+			if ($params->get('carousel_show_controls', 1))
+			{
+				$options[] = '"nav":true';
+			}
+			if ($params->get('carousel_show_indicators', 1))
+			{
+				$options[] = '"dots":true';
+			}
+			echo implode(',', $options);
+		?>}'>
 		<?php foreach ($list as $item) : ?>
 			<div<?php echo $item->state == 0 ? ' class=\"system-unpublished\"' : null; ?> itemprop="blogPost" itemscope itemtype="https://schema.org/BlogPosting">
 				<?php require JModuleHelper::getLayoutPath('mod_articles_news', $params->get('carousel_layout', ($module->position == 'right' || $params->get('carousel_count', 1) > 1) ? '_card' : '_hcell')); ?>


### PR DESCRIPTION
### Summary of Changes
Aggiunta funzionalità responsive.
![1](https://user-images.githubusercontent.com/12718836/156431553-c9122c08-6381-4c30-8cb0-056c7f138c59.png)

### Testing Instructions
Creare un modulo di tipo Articles - Newsflash. Impostare layout a carousel ed il numero di immagini a responsive

### Expected result
Disposizione su una due o tre colonne in base alla risoluzione

![2](https://user-images.githubusercontent.com/12718836/156431868-97e01c95-8745-481a-ab8d-2f1fc01d6b67.png)

![3](https://user-images.githubusercontent.com/12718836/156431883-04104491-6167-4563-a594-323252af3c9e.png)

![4](https://user-images.githubusercontent.com/12718836/156431904-1979317f-a943-4fb3-af82-4f799f8eea30.png)

### Actual result
Non è possibile impostare il numero di immagini a responsive.
![image](https://user-images.githubusercontent.com/12718836/156432570-dbca8dae-6546-44a9-a2be-345b43dbadd7.png)


![4](https://user-images.githubusercontent.com/12718836/156432027-c6b14ed1-a37c-480c-a6e5-6bbd39a1a8a3.png)


### Documentation Changes Required

