### PR TITLE
Corretto tipo campo CheckBox

### DIFF
--- a/plugins/system/italiapa/src/joomla/joomla/form/fields/checkbox.php
+++ b/plugins/system/italiapa/src/joomla/joomla/form/fields/checkbox.php
@@ -81,9 +81,16 @@ class JFormFieldCheckbox extends _JFormFieldCheckbox
 	public function setup(SimpleXMLElement $element, $value, $group = null)
 	{
 		$attributes = $element->attributes();
-		if (isset($attributes['hiddenLabel'])) {
+		if (isset($attributes['hiddenLabel']))
+		{
+			if (!empty($attributes['hiddenLabel']))
+			{
+				$element['label'] = "";
+			}
 			$attributes->hiddenLabel = true;
-		} else {
+		}
+		else
+		{
 			$element->addAttribute('hiddenLabel', true);
 		}
 

--- a/templates/italiapa/html/layouts/joomla/form/field/checkbox.php
+++ b/templates/italiapa/html/layouts/joomla/form/field/checkbox.php
@@ -22,32 +22,31 @@ extract($displayData);
 /**
  * Layout variables
  * -----------------
- * @var   string   $autocomplete	Autocomplete attribute for the field.
- * @var   boolean  $autofocus	   Is autofocus enabled?
- * @var   string   $class		   Classes for the input.
- * @var   string   $description	 Description of the field.
- * @var   boolean  $disabled		Is this field disabled?
- * @var   string   $group		   Group the field belongs to. <fields> section in form XML.
- * @var   boolean  $hidden		  Is this field hidden in the form?
- * @var   string   $hint			Placeholder for the field.
- * @var   string   $id			  DOM id of the field.
- * @var   string   $label		   Label of the field.
- * @var   string   $labelclass	  Classes to apply to the label.
- * @var   boolean  $multiple		Does this field support multiple values?
- * @var   string   $name			Name of the input field.
- * @var   string   $onchange		Onchange attribute for the field.
- * @var   string   $onclick		 Onclick attribute for the field.
- * @var   string   $pattern		 Pattern (Reg Ex) of value of the form field.
- * @var   boolean  $readonly		Is this field read only?
- * @var   boolean  $repeat		  Allows extensions to duplicate elements.
- * @var   boolean  $required		Is this field required?
- * @var   integer  $size			Size attribute of the input.
- * @var   boolean  $spellcheck	  Spellcheck state for the form field.
- * @var   string   $validate		Validation rules to apply.
- * @var   string   $value		   Value attribute of the field.
- * @var   array	$checkedOptions  Options that will be set as checked.
- * @var   boolean  $hasValue		Has this field a value assigned?
- * @var   array	$options		 Options available for this field.
+ * @var   string              $autocomplete    Autocomplete attribute for the field.
+ * @var   boolean             $autofocus       Is autofocus enabled?
+ * @var   string              $class           Classes for the input.
+ * @var   string              $description     Description of the field.
+ * @var   boolean             $disabled        Is this field disabled?
+ * @var   \JFormFieldCheckbox $field           The field object
+ * @var   string              $group           Group the field belongs to. <fields> section in form XML.
+ * @var   boolean             $hidden          Is this field hidden in the form?
+ * @var   string              $hint            Placeholder for the field.
+ * @var   string              $id              DOM id of the field.
+ * @var   string              $label           Label of the field.
+ * @var   string              $labelclass      Classes to apply to the label.
+ * @var   boolean             $multiple        Does this field support multiple values?
+ * @var   string              $name            Name of the input field.
+ * @var   string              $onchange        Onchange attribute for the field.
+ * @var   string              $onclick         Onclick attribute for the field.
+ * @var   string              $pattern         Pattern (Reg Ex) of value of the form field.
+ * @var   string              $validationtext  The validation text of invalid value of the form field.
+ * @var   boolean             $readonly        Is this field read only?
+ * @var   boolean             $repeat          Allows extensions to duplicate elements.
+ * @var   boolean             $required        Is this field required?
+ * @var   integer             $size            Size attribute of the input.
+ * @var   boolean             $spellcheck      Spellcheck state for the form field.
+ * @var   string              $validate        Validation rules to apply.
+ * @var   string              $value           Value attribute of the field.
  */
 
 // Including fallback code for HTML5 non supported browsers.
@@ -55,17 +54,18 @@ JHtml::_('jquery.framework');
 JHtml::_('script', 'system/html5fallback.js', array('version' => 'auto', 'relative' => true, 'conditional' => 'lt IE 9'));
 
 // Initialize some option attributes.
-$checked		= in_array((string) $value, $checkedOptions, true) ? 'checked' : '';
+$checked		= $field->checked ? 'checked' : '';
 $optionClass	= 'class="' . trim($class . ' Form-input ' . $disabled) . '"';
 $optionDisabled = $disabled;
 
-// Initialize some JavaScript option attributes.
-$onclick  = !empty($option->onclick) ? 'onclick="' . $option->onclick . '"' : '';
-$onchange = !empty($option->onchange) ? 'onchange="' . $option->onchange . '"' : '';
 
-$oid		= $id . $i;
-$value	  = htmlspecialchars($option->value, ENT_COMPAT, 'UTF-8');
-$attributes = array_filter(array($checked, $optionClass, $optionDisabled, $onchange, $onclick));
+// Initialize some JavaScript option attributes.
+$onclick        = !empty($onclick) ? 'onclick="' . $onclick . '"' : '';
+$onchange       = !empty($onchange) ? 'onchange="' . $onchange . '"' : '';
+
+$oid		    = $id . '0';
+$value	        = htmlspecialchars(empty($field->value) ?: $field->value, ENT_COMPAT, 'UTF-8');
+$attributes     = array_filter(array($checked, $optionClass, $optionDisabled, $onchange, $onclick));
 
 /**
  * The format of the input tag to be filled in using sprintf.
@@ -74,12 +74,10 @@ $attributes = array_filter(array($checked, $optionClass, $optionDisabled, $oncha
  *    %3 - value
  *    %4 = any other attributes
  */
-$format = '<input type="checkbox" id="%1$s" name="%2$s" value="%3$s" %4$s /><span class="Form-fieldIcon" role="presentation"></span>';
+$format         = '<input type="checkbox" id="%1$s" name="%2$s" value="%3$s" %4$s /><span class="Form-fieldIcon" role="presentation"></span>';
 
 // The alt option for JText::alt
-$alt = preg_replace('/[^a-zA-Z0-9_\-]/', '_', $name);
-
-$oid = $id . "0";
+$alt            = preg_replace('/[^a-zA-Z0-9_\-]/', '_', $name);
 ?>
 
 <fieldset class="Form-fieldset">


### PR DESCRIPTION
Pull Request for Issue #451.

### Summary of Changes
Corretto campo di tipo CheckBox

### Testing Instructions
Componenti > Contatti
- Crea un nuovo contatto

Menu

- Crea una nuova voce di menu di tipo > Singolo contatto
- Seleziona il contatto precedente creato

Configurazione Globale > Contatti

- TAB >> Modulo contatto
- Invia copia al mittente >> MOSTRA

### Expected result
![image](https://user-images.githubusercontent.com/12718836/157895710-5c588337-4a52-4d9b-ac18-e22666e1fb8b.png)

### Actual result
Notice: Undefined variable: checkedOptions in

templates/italiapa/html/layouts/joomla/form/field/checkbox.php on line 58
Warning: in_array() expects parameter 2 to be array, null given in

templates/italiapa/html/layouts/joomla/form/field/checkbox.php on line 58
Notice: Undefined variable: i in

/italiapa/html/layouts/joomla/form/field/checkbox.php on line 66
Notice: Undefined variable: option in

/templates/italiapa/html/layouts/joomla/form/field/checkbox.php on line 67
Notice: Trying to get property 'value' of non-object in

/templates/italiapa/html/layouts/joomla/form/field/checkbox.php on line 67

![image](https://user-images.githubusercontent.com/12718836/157895790-8f072a25-c9b7-4250-88da-e6883323f06f.png)

### Documentation Changes Required

