### PR TITLE
Modulo Carousel Responsive

### DIFF
--- a/templates/italiapa/html/mod_carousel/default.php
+++ b/templates/italiapa/html/mod_carousel/default.php
@@ -48,10 +48,28 @@ defined('_JEXEC') or die;
 		<?php $count = $params->get('count', 1); ?>
 		<div class="owl-carousel owl-theme" role="region" id="carousel-<?php echo $module->id; ?>" aria-label="carousel-<?php echo $module->title; ?>"
 			data-carousel-options='{<?php
-			echo ($count > 0) ? '"items":' . $count . ',"responsive":false,"lazyLoad":true' : '';
-			echo $params->get('auto_sliding', 1) ? ',"autoplay":true,"autoplaySpeed":' . $params->get('speed', 1000) . ',"autoplayTimeout":' . $params->get('interval', 5000) : '';
-			echo $params->get('loop', 1) ? ',"loop":true' : '';
-			echo $params->get('show_indicators', 1) ? ',"dots":true' : '';
+				$options = [];
+				if ($count > 0) 
+				{
+					$options[] = '"items":' . $count;
+					$options[] = '"responsive":false';
+					$options[] = '"lazyLoad":true';
+				}
+				if ($params->get('auto_sliding', 1))
+				{
+					$options[] = '"autoplay":true';
+					$options[] = '"autoplaySpeed":' . $params->get('speed', 1000);
+					$options[] = '"autoplayTimeout":' . $params->get('interval', 5000);
+				}
+				if ($params->get('loop', 1))
+				{
+					$options[] = '"loop":true';
+				}
+				if ($params->get('show_indicators', 1))
+				{
+					$options[] = '"dots":true';
+				}
+				echo implode(',', $options);
 			?>}'>
 			<?php
 			$i = 1000 * (int)$module->id;


### PR DESCRIPTION
### Summary of Changes
Corretto Modulo Carousel visualizzazione Responsive

### Testing Instructions
Creare un modulo di tipo carousel.
Impostare la visualizzazione responsive settando il # di immagini a Responsive
![image](https://user-images.githubusercontent.com/12718836/158012794-9c16e1f0-828e-4cc2-bd92-d323c63e476f.png)
Lasciare il layout default
![image](https://user-images.githubusercontent.com/12718836/158012805-b641914b-78c8-4831-acc7-1299a7d1198f.png)

### Expected result
Visualizzazione corretta del carousel secondo le impostazioni scelte. Indicatori, Controlli e scorrimento automatico.
![image](https://user-images.githubusercontent.com/12718836/158012841-2f6a49bf-3541-4c17-a001-96237c7793d9.png)

### Actual result
Non vengono visualizzati gli indicatori e lo scorrimento automatico non funziona.
![image](https://user-images.githubusercontent.com/12718836/158012857-dae8ee55-aa97-4209-bb09-9788b105e3db.png)
