### PR TITLE
Modulo Carousel Responsive layout News

### DIFF
--- a/templates/italiapa/html/mod_carousel/news.php
+++ b/templates/italiapa/html/mod_carousel/news.php
@@ -30,10 +30,28 @@ defined('_JEXEC') or die;
 		<?php $count = $params->get('count', 1); ?>
 		<div class="owl-carousel news-theme" role="region" id="carousel-<?php echo $module->id; ?>" aria-label="carousel-<?php echo $module->title; ?>"
 			data-carousel-options='{<?php
-			echo ($count > 0) ? '"items":' . $count . ',"responsive":false,"lazyLoad":true' : '';
-			echo $params->get('auto_sliding', 1) ? ',"autoplay":true,"autoplaySpeed":' . $params->get('speed', 1000) . ',"autoplayTimeout":' . $params->get('interval', 5000) : '';
-			echo $params->get('loop', 1) ? ',"loop":true' : '';
-			echo $params->get('show_indicators', 1) ? ',"dots":true' : '';
+				$options = [];
+				if ($count > 0) 
+				{
+					$options[] = '"items":' . $count;
+					$options[] = '"responsive":false';
+					$options[] = '"lazyLoad":true';
+				}
+				if ($params->get('auto_sliding', 1))
+				{
+					$options[] = '"autoplay":true';
+					$options[] = '"autoplaySpeed":' . $params->get('speed', 1000);
+					$options[] = '"autoplayTimeout":' . $params->get('interval', 5000);
+				}
+				if ($params->get('loop', 1))
+				{
+					$options[] = '"loop":true';
+				}
+				if ($params->get('show_indicators', 1))
+				{
+					$options[] = '"dots":true';
+				}
+				echo implode(',', $options);
 			?>}'>
 			<?php
 			$i = 1000 * (int)$module->id;


### PR DESCRIPTION
### Summary of Changes
Corretto Modulo Carousel visualizzazione Responsive layout News

### Testing Instructions
[](https://user-images.githubusercontent.com/12718836/158012794-9c16e1f0-828e-4cc2-bd92-d323c63e476f.png)Creare un modulo di tipo carousel.
Impostare la visualizzazione responsive settando il # di immagini a Responsive
![image](https://user-images.githubusercontent.com/12718836/158013160-2c609b43-6815-4b39-b969-2c6ae6c1bfef.png)
Impostare il layout news
![image](https://user-images.githubusercontent.com/12718836/158013182-7ebc1f5f-d393-4f8b-bcff-b5141af132ce.png)

### Expected result
Visualizzazione corretta del carousel secondo le impostazioni scelte. Indicatori, Controlli e scorrimento automatico.
![image](https://user-images.githubusercontent.com/12718836/158013211-7e97dc84-8c11-426e-b27d-d4b13c2539c5.png)

### Actual result
Non vengono visualizzati gli indicatori e lo scorrimento automatico non funziona.
![image](https://user-images.githubusercontent.com/12718836/158013220-82902e10-4cd7-43bd-9f5b-32053eccc93a.png)
