### PR TITLE
Anteprima di stampa articolo - Pulsante stampa

### DIFF
--- a/templates/italiapa/html/com_content/article/default.php
+++ b/templates/italiapa/html/com_content/article/default.php
@@ -107,7 +107,7 @@ $imgfloat = empty($images->float_fulltext) ? $params->get('float_fulltext') : $i
 			<?php if ($useDefList) : ?>
 				<div id="pop-print" class="u-hiddenPrint">
 					<?php
-					$text = JLayoutHelper::render('joomla.content.icons.print_screen', array('params' => $params, 'legacy' => $legacy));
+					$text = JLayoutHelper::render('joomla.content.icons.print_screen', array('params' => $params));
 					echo '<a href="#" onclick="window.print();return false;" class="Button Button--default u-text-r-xs u-linkClean">' . $text . '</a>';
 					?>
 				</div>


### PR DESCRIPTION
Pull Request for Issue #463.

### Summary of Changes
Corretto pulsante stampa in anteprima di stampa articolo

### Testing Instructions
Aprire un articolo e premere il pulsante stampa per aprire la pagina di anteprima.

### Expected result
Corretta visualizzazione del pulsante stampa

### Actual result
Viene visualizzato la notifica
Notice: Undefined variable: legacy in ../templates/italiapa/html/com_content/article/default.php on line 110



### Documentation Changes Required

