### PR TITLE
Corretto reindirizzamento dopo login

### DIFF
--- a/templates/italiapa/html/com_users/login/default_login.php
+++ b/templates/italiapa/html/com_users/login/default_login.php
@@ -139,8 +139,8 @@ JText::script('TPL_ITALIAPA_UNTRUST_THIS_BROWSER');
 		<div class="Form-field Grid-cell u-textRight">
 			<button type="submit" class="Button Button--default u-text-xs"><?php echo JText::_('JLOGIN'); ?></button>
 		</div>
-		<?php $return = $this->form->getValue('return'); ?>
-		<?php $return = empty($return) ? $this->params->get('login_redirect_url', $this->params->get('login_redirect_menuitem')) : JUri::root() . '/' . $return; ?> 
+		<?php $return = $this->form->getValue('return', '', $this->params->get('login_redirect_url', $this->params->get('login_redirect_menuitem'))); ?>
+		<input type="hidden" name="clean_return" value="<?php echo $return; ?>" />
 		<input type="hidden" name="return" value="<?php echo base64_encode($return); ?>" />
 		<?php echo JHtml::_('form.token'); ?>
 	</form>


### PR DESCRIPTION
### Summary of Changes
Corretto il reindirizzamento ad una risorsa non pubblica, dopo l'autenticazione.

### Testing Instructions
- Creare un articolo con accesso di tipo Registered
![image](https://user-images.githubusercontent.com/12718836/164913890-005d016c-1f1c-4eb9-9519-dd195fe06e24.png)
- Creare una voce di menu di tipo Singolo articolo collegata all'articolo appena creato
![image](https://user-images.githubusercontent.com/12718836/164913958-6b76c66b-db33-4793-ba46-4b99f7f2549d.png)
- Abilitare l'opzione Link non autorizzati dalle opzioni Articoli
![image](https://user-images.githubusercontent.com/12718836/164913783-53dddfca-40e1-402e-8deb-d0dce740415e.png)

### Expected result
Al click sulla voce di menu si viene indirizzati alla pagina di login, per poi essere reindirizzati all'articolo.

### Actual result
Al momento si presenta la pagina di errore 404. Il reindirizzamento non è corretto. Viene ripetuto due volte l'indirizzo del sito web nella URL:
`https://www.eshiol.it//https://www.eshiol.it/singolo-articolo.html`

### Documentation Changes Required
