### PR TITLE
Modulo News Flash - Visualizzazione Tags

### DIFF
--- a/plugins/system/italiapa/forms/mod_articles_news.xml
+++ b/plugins/system/italiapa/forms/mod_articles_news.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form>
+	<fields name="params">
+		<fieldset name="basic">
+			<field name="show_tags" type="radio" label="JGLOBAL_SHOW_TAGS_LABEL" description="JGLOBAL_SHOW_TAGS_DESC" class="btn-group btn-group-yesno" default="0">
+				<option value="1">JSHOW</option>
+				<option value="0">JHIDE</option>
+			</field>
+		</fieldset>
+	</fields>
+</form>

--- a/plugins/system/italiapa/italiapa.php
+++ b/plugins/system/italiapa/italiapa.php
@@ -101,13 +101,11 @@ class PlgSystemItaliaPA extends JPlugin
 
 			Form::addFormPath(dirname(__FILE__) . '/forms');
 
+			$form->loadFile($data->module, false);
+
 			if ($data->module == 'mod_articles_news')
 			{
 				$form->loadFile('carousel', false);
-			}
-			else
-			{
-				$form->loadFile($data->module, false);
 			}
 		}
 		elseif ($formName == 'com_config.modules')

--- a/templates/italiapa/html/mod_articles_news/_card.php
+++ b/templates/italiapa/html/mod_articles_news/_card.php
@@ -53,6 +53,15 @@ $assocParam = (JLanguageAssociations::isEnabled() && $item->params->get('show_as
 							echo $item->afterDisplayTitle;
 						endif;
 
+						if ($params->get('show_tags', 0)) :
+							$itemtags = (new JHelperTags)->getItemTags('com_content.article', $item->id);
+							if ($itemtags) : ?>
+								<div class="mod-articles-news-tags">
+									<?php echo JLayoutHelper::render('joomla.content.tags', $itemtags); ?>
+								</div>
+							<?php endif;
+						endif;
+
 						echo $item->beforeDisplayContent;
 
 						if ($params->get('show_introtext', '1')) :

--- a/templates/italiapa/html/mod_articles_news/_cell.php
+++ b/templates/italiapa/html/mod_articles_news/_cell.php
@@ -55,6 +55,15 @@ $assocParam = (JLanguageAssociations::isEnabled() && $item->params->get('show_as
 			echo $item->afterDisplayTitle;
 		endif;
 
+		if ($params->get('show_tags', 0)) :
+			$itemtags = (new JHelperTags)->getItemTags('com_content.article', $item->id);
+			if ($itemtags) : ?>
+				<div class="mod-articles-news-tags">
+					<?php echo JLayoutHelper::render('joomla.content.tags', $itemtags); ?>
+				</div>
+			<?php endif;
+		endif;
+
 		echo $item->beforeDisplayContent;
 
 		if ($params->get('show_introtext', '1')) :

--- a/templates/italiapa/html/mod_articles_news/_hcell.php
+++ b/templates/italiapa/html/mod_articles_news/_hcell.php
@@ -63,6 +63,15 @@ $assocParam = (JLanguageAssociations::isEnabled() && $item->params->get('show_as
 					echo $item->afterDisplayTitle;
 				endif;
 
+				if ($params->get('show_tags', 0)) :
+					$itemtags = (new JHelperTags)->getItemTags('com_content.article', $item->id);
+					if ($itemtags) : ?>
+						<div class="mod-articles-news-tags">
+							<?php echo JLayoutHelper::render('joomla.content.tags', $itemtags); ?>
+						</div>
+					<?php endif;
+				endif; ?>
+
 				echo $item->beforeDisplayContent;
 
 				if ($params->get('show_introtext', '1')) :


### PR DESCRIPTION
Pull Request for Issue #462 .

### Summary of Changes
Aggiunta l'opzione Visualizza tags al Modulo News Flash

### Testing Instructions
Creare un modulo di tipo News Flash
Attivare l'opzione Mostra tags
![image](https://user-images.githubusercontent.com/12718836/169146048-f725aca6-d462-498b-8df6-49eabe7510d9.png)

### Expected result
Il modulo presenta gli articoli con i tags.
![image](https://user-images.githubusercontent.com/12718836/169146657-754e1901-450f-4296-8c47-41f08d0f814b.png)


### Actual result
Non esiste l'opzione Mostra tags. Il modulo presenta gli articoli senza tags.
![image](https://user-images.githubusercontent.com/12718836/169146331-9082545a-f8f7-4f66-9fe0-62c53ec40612.png)


### Documentation Changes Required

