### PR TITLE
Corretto errore 0 Class 'FieldsHelper' not found

### DIFF
--- a/plugins/content/ipapagebreak/ipapagebreak.php
+++ b/plugins/content/ipapagebreak/ipapagebreak.php
@@ -79,15 +79,6 @@ class PlgContentIpapagebreak extends JPlugin
 				), JLOG::ALL & ~ JLOG::DEBUG, array(
 						'plg_content_ipapagebreak'
 				));
-		if ($this->params->get('phpconsole') && class_exists('JLogLoggerPhpconsole'))
-		{
-			JLog::addLogger(array(
-					'logger' => 'phpconsole',
-					'extension' => 'plg_content_ipapagebreak_phpconsole'
-			), JLOG::DEBUG, array(
-					'plg_content_ipapagebreak'
-			));
-		}
 		JLog::add(new JLogEntry(__METHOD__, JLog::DEBUG, 'plg_content_ipapagebreak'));
 
 		JFactory::getLanguage()->load('plg_content_pagebreak', JPATH_ADMINISTRATOR);
@@ -123,13 +114,16 @@ class PlgContentIpapagebreak extends JPlugin
 		}
 
 		$style = $this->params->get('style', 'pages');
-		$fields = FieldsHelper::getFields('com_content.article', $row);
-		foreach ($fields as $field)
+		if (JPluginHelper::getPlugin('system', 'fields'))
 		{
-			if (($field->name == 'plg-content-ipapagebreak-style') && $field->rawvalue)
+			$fields = FieldsHelper::getFields('com_content.article', $row);
+			foreach ($fields as $field)
 			{
-				$style = $field->rawvalue;
-				break;
+				if (($field->name == 'plg-content-ipapagebreak-style') && $field->rawvalue)
+				{
+					$style = $field->rawvalue;
+					break;
+				}
 			}
 		}
 

--- a/plugins/content/ipapagebreak/ipapagebreak.php
+++ b/plugins/content/ipapagebreak/ipapagebreak.php
@@ -114,7 +114,7 @@ class PlgContentIpapagebreak extends JPlugin
 		}
 
 		$style = $this->params->get('style', 'pages');
-		if (JPluginHelper::getPlugin('system', 'fields'))
+		if (JPluginHelper::isEnabled('system', 'fields'))
 		{
 			$fields = FieldsHelper::getFields('com_content.article', $row);
 			foreach ($fields as $field)

--- a/templates/italiapa/html/com_content/featured/heronews_item.php
+++ b/templates/italiapa/html/com_content/featured/heronews_item.php
@@ -20,13 +20,16 @@ defined('_JEXEC') or die;
 <div class="Carousel-item Grid Hero Hero-<?php echo $this->item->id; ?>">
 	<div class="Grid-cell u-sizeFull">
 		<?php
-			foreach ($this->item->jcfields as $jcField)
+			if (JPluginHelper::getPlugin('system', 'fields'))
 			{
-				if (($jcField->name == 'image-heronews') && $jcField->rawvalue)
+				foreach ($this->item->jcfields as $jcField)
 				{
-					JFactory::getDocument()->addStyleDeclaration(
-							".Hero-" . $this->item->id . " {background-image: url('" . JUri::root(true) . '/' . htmlspecialchars($jcField->rawvalue, ENT_COMPAT, 'UTF-8') . "') !important;}"
-							);
+					if (($jcField->name == 'image-heronews') && $jcField->rawvalue)
+					{
+						JFactory::getDocument()->addStyleDeclaration(
+								".Hero-" . $this->item->id . " {background-image: url('" . JUri::root(true) . '/' . htmlspecialchars($jcField->rawvalue, ENT_COMPAT, 'UTF-8') . "') !important;}"
+								);
+					}
 				}
 			}
 		?>

--- a/templates/italiapa/html/com_content/featured/heronews_item.php
+++ b/templates/italiapa/html/com_content/featured/heronews_item.php
@@ -20,7 +20,7 @@ defined('_JEXEC') or die;
 <div class="Carousel-item Grid Hero Hero-<?php echo $this->item->id; ?>">
 	<div class="Grid-cell u-sizeFull">
 		<?php
-			if (JPluginHelper::getPlugin('system', 'fields'))
+			if (JPluginHelper::isEnabled('system', 'fields'))
 			{
 				foreach ($this->item->jcfields as $jcField)
 				{


### PR DESCRIPTION
### Summary of Changes
Corretto errore 0 Class 'FieldsHelper' not found, quando il plugin System - Fields è disabilitato ed il plugin Content - Page Break for ItaliaPA è abilitato.


### Testing Instructions
Disabilitare il plugin System - Fields ed abilitare il plugin Content - Page Break for ItaliaPA
Creare un articolo suddiviso in pagine (page break).

### Expected result
La pagina si vede correttamente suddivisa in pagine


### Actual result
Viene mostrato l'errore: 0 Class 'FieldsHelper' not found


### Documentation Changes Required

