### PR TITLE
Modulo Elenco categorie - layout focus: corretta visualizzazione Icona categoria

### DIFF
--- a/templates/italiapa/html/mod_articles_categories/focus_items.php
+++ b/templates/italiapa/html/mod_articles_categories/focus_items.php
@@ -27,7 +27,7 @@ $lang  = JFactory::getLanguage();
 			<div class="u-nbfc u-borderShadow-m u-borderRadius-m u-color-grey-30 u-background-white Arrange-sizeFill">
 				<div class="u-text-r-l u-padding-r-all u-layout-prose">
 					<?php $icon = ''; ?>
-					<?php if (JPluginHelper::getPlugin('system', 'fields')) : ?>
+					<?php if (JPluginHelper::isEnabled('system', 'fields')) : ?>
 						<?php $jcFields = FieldsHelper::getFields('com_content.categories', $item, true); ?>
 						<?php foreach ($jcFields as $jcField) : ?>
 							<?php if (($jcField->name == 'categoryicon') && $jcField->rawvalue): ?>

--- a/templates/italiapa/html/mod_articles_categories/focus_items.php
+++ b/templates/italiapa/html/mod_articles_categories/focus_items.php
@@ -26,8 +26,8 @@ $lang  = JFactory::getLanguage();
 		<div class="Grid-cell <?php echo $responsiveClass ?: 'u-md-size1of3 u-lg-size1of3'; ?> u-flex u-margin-r-bottom u-flexJustifyCenter">
 			<div class="u-nbfc u-borderShadow-m u-borderRadius-m u-color-grey-30 u-background-white Arrange-sizeFill">
 				<div class="u-text-r-l u-padding-r-all u-layout-prose">
+					<?php $icon = ''; ?>
 					<?php if (JPluginHelper::getPlugin('system', 'fields')) : ?>
-						<?php $icon = ''; ?>
 						<?php $jcFields = FieldsHelper::getFields('com_content.categories', $item, true); ?>
 						<?php foreach ($jcFields as $jcField) : ?>
 							<?php if (($jcField->name == 'categoryicon') && $jcField->rawvalue): ?>

--- a/templates/italiapa/html/mod_articles_categories/focus_items.php
+++ b/templates/italiapa/html/mod_articles_categories/focus_items.php
@@ -26,13 +26,15 @@ $lang  = JFactory::getLanguage();
 		<div class="Grid-cell <?php echo $responsiveClass ?: 'u-md-size1of3 u-lg-size1of3'; ?> u-flex u-margin-r-bottom u-flexJustifyCenter">
 			<div class="u-nbfc u-borderShadow-m u-borderRadius-m u-color-grey-30 u-background-white Arrange-sizeFill">
 				<div class="u-text-r-l u-padding-r-all u-layout-prose">
-					<?php $icon = ''; ?>
-					<?php $jcFields = FieldsHelper::getFields('com_content.categories', $item, true); ?>
-					<?php foreach ($jcFields as $jcField) : ?>
-						<?php if (($jcField->name == 'categoryicon') && $jcField->rawvalue): ?>
-							<?php $icon = '<span class="' . $jcField->rawvalue . '"></span> '; ?>
-						<?php endif; ?>
-					<?php endforeach; ?>
+					<?php if (JPluginHelper::getPlugin('system', 'fields')) : ?>
+						<?php $icon = ''; ?>
+						<?php $jcFields = FieldsHelper::getFields('com_content.categories', $item, true); ?>
+						<?php foreach ($jcFields as $jcField) : ?>
+							<?php if (($jcField->name == 'categoryicon') && $jcField->rawvalue): ?>
+								<?php $icon = '<span class="' . $jcField->rawvalue . '"></span> '; ?>
+							<?php endif; ?>
+						<?php endforeach; ?>
+					<?php endif; ?>
 					<h3 class="u-text-h4 u-margin-r-bottom">
 						<a class="u-text-r-m u-color-95 u-textWeight-400 u-textClean" href="<?php echo JRoute::_(ContentHelperRoute::getCategoryRoute($item->id, $item->language)); ?>">
 							<?php echo $icon . $item->title; ?>


### PR DESCRIPTION
### Summary of Changes
Corretta visualizzazione Icona categoria nel modulo Elenco categorie - layout focus, quando il plugin System - Fields è disabilitato. L'icona deve essere mostrata solo se il plugin System - fields è abilitato.


### Testing Instructions
Creare una categoria ed assegnare una icona tramite il campo aggiuntivo Icon (per esempio Icon icon-file).
Disabilitare il plugin System - fields.
creare un modulo di tipo Elenco categorie con layout focus che mostri la categoria creata.


### Expected result
La categoria non mostra l'icona.


### Actual result
La categoria mostra l'icona, nonostante il plugin System - fields sia disabilitato.


### Documentation Changes Required

