### PR TITLE
Modulo Elenco articoli - layout focus: corretta visualizzazione Icona articolo

### DIFF
--- a/templates/italiapa/html/mod_articles_category/focus.php
+++ b/templates/italiapa/html/mod_articles_category/focus.php
@@ -60,7 +60,7 @@ $moduleclass_sfx = (substr($params->get('moduleclass_sfx'), 0, 1) == ' ' ? ' ' :
 
 						<h3 class="u-text-h4 u-margin-r-bottom">
 							<?php $icon = ''; ?>
-							<?php if (JPluginHelper::getPlugin('system', 'fields')) : ?>
+							<?php if (JPluginHelper::isEnabled('system', 'fields')) : ?>
 								<?php $jcFields = FieldsHelper::getFields('com_content.article', $item, true); ?>
 								<?php foreach ($jcFields as $jcField) : ?>
 									<?php if (($jcField->name == 'articleicon') && $jcField->rawvalue): ?>

--- a/templates/italiapa/html/mod_articles_category/focus.php
+++ b/templates/italiapa/html/mod_articles_category/focus.php
@@ -28,8 +28,6 @@ for ($i = count($moduleclass_sfx) - 1; $i >= 0; $i--)
 	}
 }
 $moduleclass_sfx = (substr($params->get('moduleclass_sfx'), 0, 1) == ' ' ? ' ' : '') . implode(' ', $moduleclass_sfx);
-
-JLoader::register('FieldsHelper', JPATH_ADMINISTRATOR . '/components/com_fields/helpers/fields.php');
 ?>
 <div class="Grid Grid--withGutter category-module mod-list">
 	<?php $i = 1; ?>
@@ -61,13 +59,15 @@ JLoader::register('FieldsHelper', JPATH_ADMINISTRATOR . '/components/com_fields/
 						<?php endif; ?>
 
 						<h3 class="u-text-h4 u-margin-r-bottom">
-							<?php $icon = ''; ?>
-							<?php $jcFields = FieldsHelper::getFields('com_content.article', $item, true); ?>
-							<?php foreach ($jcFields as $jcField) : ?>
-								<?php if (($jcField->name == 'articleicon') && $jcField->rawvalue): ?>
-									<?php $icon = '<span class="' . $jcField->rawvalue . '"></span> '; ?>
-								<?php endif; ?>
-							<?php endforeach; ?>
+							<?php if (JPluginHelper::getPlugin('system', 'fields')) : ?>
+								<?php $icon = ''; ?>
+								<?php $jcFields = FieldsHelper::getFields('com_content.article', $item, true); ?>
+								<?php foreach ($jcFields as $jcField) : ?>
+									<?php if (($jcField->name == 'articleicon') && $jcField->rawvalue): ?>
+										<?php $icon = '<span class="' . $jcField->rawvalue . '"></span> '; ?>
+									<?php endif; ?>
+								<?php endforeach; ?>
+							<?php endif; ?>
 
 							<?php if ($params->get('link_titles') == 1) : ?>
 								<a class="mod-articles-category-title u-text-r-m u-color-95 u-textWeight-400 u-textClean <?php echo $item->active; ?>" href="<?php echo $item->link; ?>" itemprop="url">

--- a/templates/italiapa/html/mod_articles_category/focus.php
+++ b/templates/italiapa/html/mod_articles_category/focus.php
@@ -59,8 +59,8 @@ $moduleclass_sfx = (substr($params->get('moduleclass_sfx'), 0, 1) == ' ' ? ' ' :
 						<?php endif; ?>
 
 						<h3 class="u-text-h4 u-margin-r-bottom">
+							<?php $icon = ''; ?>
 							<?php if (JPluginHelper::getPlugin('system', 'fields')) : ?>
-								<?php $icon = ''; ?>
 								<?php $jcFields = FieldsHelper::getFields('com_content.article', $item, true); ?>
 								<?php foreach ($jcFields as $jcField) : ?>
 									<?php if (($jcField->name == 'articleicon') && $jcField->rawvalue): ?>


### PR DESCRIPTION
### Summary of Changes
Corretta visualizzazione Icona articolo nel modulo Elenco articoli - layout focus, quando il plugin System - Fields è disabilitato. L'icona deve essere mostrata solo se il plugin System - fields è abilitato.


### Testing Instructions
Creare un articolo ed assegnare una icona tramite il campo aggiuntivo Icon (per esempio Icon icon-file).
Disabilitare il plugin System - fields.
Creare un modulo di tipo Elenco articoli con layout focus che mostri l'articolo creato.


### Expected result
Il modulo non mostra l'icona dell'articolo.


### Actual result
Il modulo mostra l'icona dell'articolo, nonostante il plugin System - fields sia disabilitato.


### Documentation Changes Required

