### PR TITLE
feat: category blog layout focus mostra link

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_system_italiapa.ini
+++ b/administrator/language/en-GB/en-GB.plg_system_italiapa.ini
@@ -22,3 +22,5 @@ PLG_SYSTEM_ITALIAPA_CAROUSEL_SHOW_INDICATORS_DESC="Adds indicators for the carou
 PLG_SYSTEM_ITALIAPA_CAROUSEL_SHOW_INDICATORS_LABEL="Show indicators"
 PLG_SYSTEM_ITALIAPA_CAROUSEL_SPEED_DESC="Specifies the time (in milliseconds) a transition effect takes to complete."
 PLG_SYSTEM_ITALIAPA_CAROUSEL_SPEED_LABEL="Speed"
+PLG_SYSTEM_ITALIAPA_SHOW_URLS_DESC="Show the links for each article."
+PLG_SYSTEM_ITALIAPA_SHOW_URLS_LABEL="Show Links"

--- a/administrator/language/it-IT/it-IT.plg_system_italiapa.ini
+++ b/administrator/language/it-IT/it-IT.plg_system_italiapa.ini
@@ -21,3 +21,5 @@ PLG_SYSTEM_ITALIAPA_CAROUSEL_SHOW_INDICATORS_DESC="Aggiunge indicatori per il ca
 PLG_SYSTEM_ITALIAPA_CAROUSEL_SHOW_INDICATORS_LABEL="Mostra indicatori"
 PLG_SYSTEM_ITALIAPA_CAROUSEL_SPEED_DESC="Specifica il tempo (in millisecondi) necessario per completare un effetto di transizione da una slide ad un'altra."
 PLG_SYSTEM_ITALIAPA_CAROUSEL_SPEED_LABEL="Velocità"
+PLG_SYSTEM_ITALIAPA_SHOW_URLS_DESC="Mostra i link per ciascun articolo"
+PLG_SYSTEM_ITALIAPA_SHOW_URLS_LABEL="Mostra Link"

--- a/plugins/system/italiapa/forms/com_content_category_focus.xml
+++ b/plugins/system/italiapa/forms/com_content_category_focus.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form>
+	<fields name="params">
+		<fieldset name="advanced">
+			<field type="spacer" hr="true"/>
+			<field name="show_urls" type="radio" label="PLG_SYSTEM_ITALIAPA_SHOW_URLS_LABEL" description="PLG_SYSTEM_ITALIAPA_SHOW_URLS_DESC" class="btn-group btn-group-yesno" default="0">
+				<option value="1">JSHOW</option>
+				<option value="0">JHIDE</option>
+			</field>
+		</fieldset>
+	</fields>
+</form>

--- a/plugins/system/italiapa/italiapa.php
+++ b/plugins/system/italiapa/italiapa.php
@@ -147,7 +147,7 @@ class PlgSystemItaliaPA extends JPlugin
 			$form->loadFile(
 					(isset($data->request['option']) ? $data->request['option'] : ''). '_' .
 					(isset($data->request['view']) ? $data->request['view'] : '') . '_' .
-					(isset($data->request['layout']) ? $data->request['layout'] : 'default'));
+					(isset($data->request['layout']) ? str_replace('italiapa:', '', $data->request['layout']) : 'default'));
 		}
 	}
 

--- a/templates/italiapa/html/com_content/category/focus_links.php
+++ b/templates/italiapa/html/com_content/category/focus_links.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Templates.ItaliaPA
+ *
+ * @version     __DEPLOY_VERSION__
+ *
+ * @author      Helios Ciancio <info (at) eshiol (dot) it>
+ * @link        https://www.eshiol.it
+ * @copyright   Copyright (C) 2017 - 2022 Helios Ciancio. All rights reserved
+ * @license     http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL v3
+ * Template ItaliaPA is free software. This version may have been modified
+ * pursuant to the GNU General Public License, and as distributed it includes
+ * or is derivative of works licensed under the GNU General Public License or
+ * other free or open source software licenses.
+ */
+
+defined('_JEXEC') or die;
+
+// Create shortcut
+$urls = json_decode($this->item->urls);
+
+$class = "Button Button--default u-text-r-xs u-border-none";
+
+// Create shortcuts to some parameters.
+$params = $this->item->params;
+if ($urls && (!empty($urls->urla) || !empty($urls->urlb) || !empty($urls->urlc))) :
+?>
+
+<div class="Grid u-margin-top-xxl">
+	<?php
+        $urlarray = array(
+            array($urls->urla, $urls->urlatext, $urls->targeta, 'a'),
+            array($urls->urlb, $urls->urlbtext, $urls->targetb, 'b'),
+            array($urls->urlc, $urls->urlctext, $urls->targetc, 'c')
+        );
+        foreach ($urlarray as $url) :
+            $link = $url[0];
+            $label = $url[1];
+            $target = $url[2];
+            $id = $url[3];
+
+            if (!$link) :
+                continue;
+            endif;
+
+            // If no label is present, take the link
+            $label = $label ?: $link;
+
+            // If no target is present, use the default
+            $target = $target ?: $params->get('target'.$id);
+            ?>
+            <div class="Grid-cell--center content-links-<?php echo $id; ?>">
+            <?php
+                // Compute the correct link
+
+                switch ($target)
+                {
+                    case 1:
+                        // open in a new window
+                        echo '<a class="' . $class .'" href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '" target="_blank"  rel="nofollow noopener noreferrer">' .
+                            htmlspecialchars($label, ENT_COMPAT, 'UTF-8') .'</a>';
+                        break;
+
+                    case 2:
+                        // open in a popup window
+                        $attribs = 'toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=600,height=600';
+                        echo '<a class="' . $class . '" href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '" onclick="window.open(this.href, \'targetWindow\', \'' . $attribs . '\'); return false;" rel="noopener noreferrer">' .
+                            htmlspecialchars($label, ENT_COMPAT, 'UTF-8').'</a>';
+                        break;
+                    case 3:
+                        // open in a modal window
+                        JHtml::_('behavior.modal', 'a.modal');
+                        echo '<a class="' . $class . ' modal" href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '"  rel="{handler: \'iframe\', size: {x:600, y:600}} noopener noreferrer">' .
+                            htmlspecialchars($label, ENT_COMPAT, 'UTF-8') . ' </a>';
+                        break;
+
+                    default:
+                        // open in parent window
+                        echo '<a class="' . $class . '" href="' .  htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '" rel="nofollow">' .
+                            htmlspecialchars($label, ENT_COMPAT, 'UTF-8') . ' </a>';
+                        break;
+                }
+            ?>
+            </div>
+    <?php endforeach; ?>
+</div>
+<?php endif; ?>

--- a/templates/italiapa/html/com_content/category/focus_simple.php
+++ b/templates/italiapa/html/com_content/category/focus_simple.php
@@ -19,9 +19,10 @@ defined('_JEXEC') or die;
 
 // Create a shortcut for params.
 $params  = &$this->item->params;
+$urls    = json_decode($this->item->urls);
 $images  = json_decode($this->item->images);
 $canEdit = $this->item->params->get('access-edit');
-$info	= $this->item->params->get('info_block_position', 0);
+$info    = $this->item->params->get('info_block_position', 0);
 
 // Check if associations are implemented. If they are, define the parameter.
 $assocParam = (JLanguageAssociations::isEnabled() && $params->get('show_associations'));
@@ -72,6 +73,10 @@ $assocParam = (JLanguageAssociations::isEnabled() && $params->get('show_associat
 				<?php endif; ?>
 			<?php endif; ?>
 
+			<?php if ($this->params->get('show_urls', 0) && isset($urls) && ($params->get('urls_position') == '0')) : ?>
+				<?php echo $this->loadTemplate('links'); ?>
+			<?php endif; ?>
+
 			<?php if ($params->get('show_readmore') && $this->item->readmore) :
 				if ($params->get('access-view')) :
 					$link = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language));
@@ -87,6 +92,9 @@ $assocParam = (JLanguageAssociations::isEnabled() && $params->get('show_associat
 
 			<?php endif; ?>
 
+			<?php if ($this->params->get('show_urls', 0) && isset($urls) && ($params->get('urls_position') == '1')) : ?>
+				<?php echo $this->loadTemplate('links'); ?>
+			<?php endif; ?>
 		</div>
 
 	</div>


### PR DESCRIPTION
### Summary of Changes
Aggiunta la possibilità di visualizzare i link degli articoli sottoforma di pulsanti, nella visualizzazione Articoli » Categoria blog (layout: Focus).


### Testing Instructions
Creare una categoria con due articoli. Negli articoli impostare almeno un link impostato (tab immagini e link)
Creare una voce di menu di tipo Articoli » Categoria blog (layout: Focus).
Abilitare l'opzione mostra link nella sezione Layout blog
![image](https://user-images.githubusercontent.com/12718836/206790851-95a4b805-d038-432e-b815-92524afe62d7.png)
Il plugin System - ItaliaPA deve essere abilitato.

### Expected result
![image](https://user-images.githubusercontent.com/12718836/206790527-27872308-4bca-44c8-9b11-91d11c61eb07.png)



### Actual result
![image](https://user-images.githubusercontent.com/12718836/206790652-be66e796-b763-4310-9a7d-6b73a59ba7d3.png)



### Documentation Changes Required

